### PR TITLE
Fix release workflow repo guard for musafety

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   publish:
-    if: github.repository == 'recodeecom/multiagent-safety'
+    if: github.repository == 'recodeecom/musafety'
     runs-on: ubuntu-latest
     environment: npm
 


### PR DESCRIPTION
## Summary
- fix release workflow repo guard to match current repository slug (`recodeecom/musafety`)
- keep the existing safety guard (publish only from canonical maintainer repo)

## Verification
- npm test (41/41 pass)
