### PR TITLE
Require explicit interactive consent before self-updating status runs

### DIFF
--- a/bin/multiagent-safety.js
+++ b/bin/multiagent-safety.js
@@ -1262,12 +1262,12 @@ function maybeSelfUpdateBeforeStatus() {
     return;
   }
 
-  const shouldUpdate = autoApproval != null
-    ? autoApproval
-    : promptYesNo(
+  const shouldUpdate = interactive
+    ? promptYesNo(
       `Update now? (${NPM_BIN} i -g ${packageJson.name}@latest)`,
       false,
-    );
+    )
+    : autoApproval;
 
   if (!shouldUpdate) {
     console.log(`[${TOOL_NAME}] Skipped update.`);

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -364,7 +364,7 @@ test('self-update prompt defaults to no when approval is not preconfigured', () 
   const source = fs.readFileSync(cliPath, 'utf8');
   assert.match(
     source,
-    /promptYesNo\(\s*`Update now\?\s*\(\$\{NPM_BIN\} i -g \$\{packageJson\.name\}@latest\)`\s*,\s*false,\s*\)/s,
+    /const shouldUpdate = interactive\s*\?\s*promptYesNo\(\s*`Update now\?\s*\(\$\{NPM_BIN\} i -g \$\{packageJson\.name\}@latest\)`\s*,\s*false,\s*\)\s*:\s*autoApproval;/s,
   );
 });
 


### PR DESCRIPTION
Automated by scripts/agent-branch-finish.sh (PR flow).