### PR TITLE
AGENTS: enforce branch-first sessions and no direct main/base edits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@ This AGENTS.md is the top-level operating contract for this repository.
 
 - For cleanup/refactor/deslop work: write a cleanup plan first.
 - Lock behavior with regression tests before cleanup edits when needed.
+- Treat `main` and any currently checked-out base branch as read-only workspaces.
+- Every new session must start by creating an isolated agent branch/worktree via `scripts/agent-branch-start.sh` before making edits.
+- If edits are found on `main`/base by mistake, immediately move them to a dedicated agent branch/worktree before continuing.
 - Prefer deletion over addition.
 - Reuse existing patterns before introducing new abstractions.
 - No new dependencies without explicit request.
@@ -87,6 +90,8 @@ OMX runtime state typically lives under `.omx/`:
 - Before deleting/replacing code, each agent must read the latest session comments/handoffs first and confirm the target code is in their owned scope.
 - If ownership is unclear or overlaps, stop that edit, post a blocker comment, and let the leader/integrator reassign scope.
 - For git isolation, each agent must start on a dedicated branch via `scripts/agent-branch-start.sh "<task-or-plan>" "<agent-name>"`.
+- Do not implement changes directly on `main` or other base branches; all edits must happen on dedicated agent branches/worktrees.
+- If the current local branch already contains accidental edits, move them to an agent branch/worktree first, then continue implementation.
 - Agent completion must use `scripts/agent-branch-finish.sh` (merge into `dev`, push, delete agent branch).
 
 1. Explicit ownership before edits


### PR DESCRIPTION
## Summary\n- make  and checked-out base branches explicitly read-only in AGENTS working agreements\n- require every new session to start with branch 'agent/agent/20260411-144234-lajos-edix-hu-task' set up to track 'origin/main'.
HEAD is now at 3f4f624 Document real VS Code repo layout and codex-auth pairing workflow (#19)
[agent-branch-start] Created branch: agent/agent/20260411-144234-lajos-edix-hu-task
[agent-branch-start] Worktree: /home/deadpool/Documents/multiagent-safety/.omx/agent-worktrees/agent__codex__20260411-144118-lajos-edix-hu-no-direct-main-branch-edits-policy/.omx/agent-worktrees/agent__agent__20260411-144234-lajos-edix-hu-task
[agent-branch-start] Next steps:
  cd "/home/deadpool/Documents/multiagent-safety/.omx/agent-worktrees/agent__codex__20260411-144118-lajos-edix-hu-no-direct-main-branch-edits-policy/.omx/agent-worktrees/agent__agent__20260411-144234-lajos-edix-hu-task"
  python3 scripts/agent-file-locks.py claim --branch "agent/agent/20260411-144234-lajos-edix-hu-task" <file...>
  # implement + commit
  bash scripts/agent-branch-finish.sh --branch "agent/agent/20260411-144234-lajos-edix-hu-task" before edits\n- document immediate recovery path when accidental edits land on main/base\n\n## Verification\n- npm test (46/46)