### PR TITLE
Keep agent branch names readable by dropping timestamp prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ and a few `agent-branch-start` runs:
 
 ```text
 GuardeX (your preferred local branch: main/dev)
-agent_codex_<timestamp>-<snapshot>-<task>
-agent_bot_<timestamp>-<snapshot>-<task>
-agent_bot_<timestamp>-<snapshot>-<task>
+agent_codex_<snapshot>-<task>
+agent_bot_<snapshot>-<task>
+agent_bot_<snapshot>-<task>-2
 ```
 
 That gives you one stable main repo view plus parallel agent worktrees in the

--- a/scripts/agent-branch-start.sh
+++ b/scripts/agent-branch-start.sh
@@ -195,15 +195,17 @@ snapshot_name="$(resolve_active_codex_snapshot_name)"
 snapshot_slug="$(sanitize_slug "$snapshot_name" "")"
 timestamp="$(date +%Y%m%d-%H%M%S)"
 if [[ -n "$snapshot_slug" ]]; then
-  branch_name="agent/${agent_slug}/${timestamp}-${snapshot_slug}-${task_slug}"
+  branch_name_base="agent/${agent_slug}/${snapshot_slug}-${task_slug}"
 else
-  branch_name="agent/${agent_slug}/${timestamp}-${task_slug}"
+  branch_name_base="agent/${agent_slug}/${task_slug}"
 fi
 
-if git show-ref --verify --quiet "refs/heads/${branch_name}"; then
-  echo "[agent-branch-start] Branch already exists: ${branch_name}" >&2
-  exit 1
-fi
+branch_name="$branch_name_base"
+branch_suffix=2
+while git show-ref --verify --quiet "refs/heads/${branch_name}"; do
+  branch_name="${branch_name_base}-${branch_suffix}"
+  branch_suffix=$((branch_suffix + 1))
+done
 
 if [[ "$WORKTREE_MODE" -eq 0 ]]; then
   if [[ "$ALLOW_IN_PLACE" -ne 1 ]]; then

--- a/templates/scripts/agent-branch-start.sh
+++ b/templates/scripts/agent-branch-start.sh
@@ -195,15 +195,17 @@ snapshot_name="$(resolve_active_codex_snapshot_name)"
 snapshot_slug="$(sanitize_slug "$snapshot_name" "")"
 timestamp="$(date +%Y%m%d-%H%M%S)"
 if [[ -n "$snapshot_slug" ]]; then
-  branch_name="agent/${agent_slug}/${timestamp}-${snapshot_slug}-${task_slug}"
+  branch_name_base="agent/${agent_slug}/${snapshot_slug}-${task_slug}"
 else
-  branch_name="agent/${agent_slug}/${timestamp}-${task_slug}"
+  branch_name_base="agent/${agent_slug}/${task_slug}"
 fi
 
-if git show-ref --verify --quiet "refs/heads/${branch_name}"; then
-  echo "[agent-branch-start] Branch already exists: ${branch_name}" >&2
-  exit 1
-fi
+branch_name="$branch_name_base"
+branch_suffix=2
+while git show-ref --verify --quiet "refs/heads/${branch_name}"; do
+  branch_name="${branch_name_base}-${branch_suffix}"
+  branch_suffix=$((branch_suffix + 1))
+done
 
 if [[ "$WORKTREE_MODE" -eq 0 ]]; then
   if [[ "$ALLOW_IN_PLACE" -ne 1 ]]; then

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -474,7 +474,7 @@ OUT
     { env: { PATH: `${fakeBin}:${process.env.PATH || ''}` } },
   );
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  assert.match(result.stdout, /Created branch: agent\/planner\/\d{8}-\d{6}-zeus-edix-hu-restore-snapshot/);
+  assert.match(result.stdout, /Created branch: agent\/planner\/zeus-edix-hu-restore-snapshot(?:-\d+)?/);
 });
 
 test('setup agent-branch-start supports explicit snapshot override without codex-auth', () => {
@@ -491,7 +491,7 @@ test('setup agent-branch-start supports explicit snapshot override without codex
     { env: { MUSAFETY_CODEX_AUTH_SNAPSHOT: 'Prod Snapshot One' } },
   );
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  assert.match(result.stdout, /Created branch: agent\/bot\/\d{8}-\d{6}-prod-snapshot-one-ship-fix/);
+  assert.match(result.stdout, /Created branch: agent\/bot\/prod-snapshot-one-ship-fix(?:-\d+)?/);
 });
 
 test('setup agent-branch-start defaults base to current branch and stores per-branch base metadata', () => {


### PR DESCRIPTION
Automated by scripts/agent-branch-finish.sh (PR flow).