### PR TITLE
Ensure version publishes always carry release notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ This AGENTS.md is the top-level operating contract for this repository.
 - Prefer deletion over addition.
 - Reuse existing patterns before introducing new abstractions.
 - No new dependencies without explicit request.
+- When publishing or bumping a version, update release notes in the same change (`README.md` release notes section and the release body when tagging).
 - Keep diffs small, reviewable, and reversible.
 - Run lint/typecheck/tests/static analysis after changes.
 - Final reports must include: changed files, simplifications made, and remaining risks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,4 @@ npm pack --dry-run
 - Keep `main` green (CI passing)
 - Prefer trusted publishing (`npm publish --provenance`)
 - Use a clean working tree and tag-based releases when possible
+- When version changes, update `README.md` release notes in the same PR/commit

--- a/README.md
+++ b/README.md
@@ -208,6 +208,20 @@ npm pack --dry-run
 
 ## Release notes
 
+### v5.0.2
+
+- Auto-closes Codex sandbox branches through PR workflow and keeps merged branch/worktree sandboxes for explicit cleanup via `gx cleanup`.
+- Runs `gx doctor` repairs from a sandbox when `main` is protected.
+- Allows tightly guarded Codex-only commits for `AGENTS.md` / `.gitignore` on protected branches.
+- Advanced package version to keep npm publishing unblocked.
+
+### v5.0.0
+
+- Rebranded the CLI to **GuardeX** with `gx`-first command UX.
+- Published under scoped package name `@imdeadpool/guardex` to avoid npm name collisions.
+- Enforced a repeatable per-message agent branch lifecycle in setup/init flows.
+- Added codex-auth-aware sandbox branch naming support.
+
 ### v0.4.6
 
 - Added repository metadata (`repository`, `bugs`, `homepage`, `funding`) in package manifest.

--- a/templates/AGENTS.multiagent-safety.md
+++ b/templates/AGENTS.multiagent-safety.md
@@ -18,6 +18,7 @@
 - If merge/rebase conflicts block auto-finish, run a conflict-resolution review pass in that sandbox branch, then rerun `agent-branch-finish.sh --via-pr` until merged.
 - Completion is not valid until these are true: commit exists on the agent branch, branch is pushed to `origin`, and PR/merge status is produced by `agent-branch-finish.sh` or `codex-agent`.
 - Per-message loop is mandatory: for every new user message/task, start a fresh agent branch/worktree, claim ownership locks, implement and verify, finish via PR/merge cleanup, then repeat for the next message/task.
+- If the change publishes or bumps a version, the same change must also update release notes/changelog entries.
 
 1. Explicit ownership before edits
 

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -5,6 +5,11 @@ const path = require('node:path');
 
 const repoRoot = path.resolve(__dirname, '..');
 const packageJsonPath = path.join(repoRoot, 'package.json');
+const readmePath = path.join(repoRoot, 'README.md');
+
+function escapeRegexLiteral(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 test('package manifest includes repository and support metadata', () => {
   const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
@@ -24,6 +29,17 @@ test('release workflow publishes with provenance in CI', () => {
   const workflowPath = path.join(repoRoot, '.github', 'workflows', 'release.yml');
   const workflow = fs.readFileSync(workflowPath, 'utf8');
   assert.match(workflow, /npm publish --provenance --access public/);
+});
+
+test('README release notes include current package version', () => {
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const readme = fs.readFileSync(readmePath, 'utf8');
+  const headingPattern = new RegExp(`^###\\s+v${escapeRegexLiteral(pkg.version)}\\b`, 'm');
+  assert.match(
+    readme,
+    headingPattern,
+    `README release notes must include heading for v${pkg.version}`,
+  );
 });
 
 test('security workflows are present and use pinned GitHub Actions SHAs', () => {


### PR DESCRIPTION
Automated by scripts/agent-branch-finish.sh (PR flow).