### PR TITLE
Allow VS Code Source Control writes on protected branches by default

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -30,7 +30,7 @@ fi
 
 allow_vscode_protected_raw="${MUSAFETY_ALLOW_VSCODE_PROTECTED_BRANCH_WRITES:-$(git config --get multiagent.allowVscodeProtectedBranchWrites || true)}"
 if [[ -z "$allow_vscode_protected_raw" ]]; then
-  allow_vscode_protected_raw="false"
+  allow_vscode_protected_raw="true"
 fi
 allow_vscode_protected="$(printf '%s' "$allow_vscode_protected_raw" | tr '[:upper:]' '[:lower:]')"
 
@@ -144,8 +144,8 @@ Use an agent branch first:
 After finishing work:
   bash scripts/agent-branch-finish.sh
 
-Optional repo override for manual VS Code protected-branch commits:
-  git config multiagent.allowVscodeProtectedBranchWrites true
+Optional repo hard-block for VS Code protected-branch commits:
+  git config multiagent.allowVscodeProtectedBranchWrites false
 
 Temporary bypass (not recommended):
   ALLOW_COMMIT_ON_PROTECTED_BRANCH=1 git commit ...

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -12,7 +12,7 @@ fi
 
 allow_vscode_protected_raw="${MUSAFETY_ALLOW_VSCODE_PROTECTED_BRANCH_WRITES:-$(git config --get multiagent.allowVscodeProtectedBranchWrites || true)}"
 if [[ -z "$allow_vscode_protected_raw" ]]; then
-  allow_vscode_protected_raw="false"
+  allow_vscode_protected_raw="true"
 fi
 allow_vscode_protected="$(printf '%s' "$allow_vscode_protected_raw" | tr '[:upper:]' '[:lower:]')"
 
@@ -77,8 +77,8 @@ if [[ "${#blocked_refs[@]}" -gt 0 ]]; then
     echo "[agent-branch-guard] Push to protected branch blocked."
     echo "[agent-branch-guard] Protected target(s): ${blocked_refs[*]}"
     echo "[agent-branch-guard] Use an agent branch and merge via PR."
-    echo "[agent-branch-guard] Optional VS Code override:"
-    echo "  git config multiagent.allowVscodeProtectedBranchWrites true"
+    echo "[agent-branch-guard] Optional repo hard-block for VS Code protected-branch push:"
+    echo "  git config multiagent.allowVscodeProtectedBranchWrites false"
     echo
     echo "Temporary bypass (not recommended):"
     echo "  ALLOW_PUSH_ON_PROTECTED_BRANCH=1 git push ..."

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ Note: the monitor dispatches Codex through explicit `--task/--agent/--base` flag
 - `gx setup` checks GitHub CLI (`gh`) and prints install guidance if missing.
 - Interactive self-update prompt defaults to **No** (`[y/N]`).
 - In initialized repos, `setup`/`install`/`fix` block protected-base writes unless explicitly overridden.
-- Direct commits/pushes to protected branches are blocked by default (including VS Code Source Control).
-- Optional repo override for manual VS Code protected-branch writes: `git config multiagent.allowVscodeProtectedBranchWrites true`.
+- VS Code Source Control can commit/push protected branches for non-Codex sessions by default.
+- Optional repo hard-block for VS Code protected-branch writes: `git config multiagent.allowVscodeProtectedBranchWrites false`.
 - Codex/agent sessions stay blocked on protected branches and must use `agent/*` branch + PR workflow.
 - On protected `main`, `gx doctor` auto-runs in a sandbox agent branch/worktree.
 - `scripts/agent-branch-start.sh` hydrates `scripts/codex-agent.sh` into new sandbox worktrees when missing, so auto-finish launcher flow stays available.

--- a/templates/githooks/pre-commit
+++ b/templates/githooks/pre-commit
@@ -30,7 +30,7 @@ fi
 
 allow_vscode_protected_raw="${MUSAFETY_ALLOW_VSCODE_PROTECTED_BRANCH_WRITES:-$(git config --get multiagent.allowVscodeProtectedBranchWrites || true)}"
 if [[ -z "$allow_vscode_protected_raw" ]]; then
-  allow_vscode_protected_raw="false"
+  allow_vscode_protected_raw="true"
 fi
 allow_vscode_protected="$(printf '%s' "$allow_vscode_protected_raw" | tr '[:upper:]' '[:lower:]')"
 
@@ -144,8 +144,8 @@ Use an agent branch first:
 After finishing work:
   bash scripts/agent-branch-finish.sh
 
-Optional repo override for manual VS Code protected-branch commits:
-  git config multiagent.allowVscodeProtectedBranchWrites true
+Optional repo hard-block for VS Code protected-branch commits:
+  git config multiagent.allowVscodeProtectedBranchWrites false
 
 Temporary bypass (not recommended):
   ALLOW_COMMIT_ON_PROTECTED_BRANCH=1 git commit ...

--- a/templates/githooks/pre-push
+++ b/templates/githooks/pre-push
@@ -12,7 +12,7 @@ fi
 
 allow_vscode_protected_raw="${MUSAFETY_ALLOW_VSCODE_PROTECTED_BRANCH_WRITES:-$(git config --get multiagent.allowVscodeProtectedBranchWrites || true)}"
 if [[ -z "$allow_vscode_protected_raw" ]]; then
-  allow_vscode_protected_raw="false"
+  allow_vscode_protected_raw="true"
 fi
 allow_vscode_protected="$(printf '%s' "$allow_vscode_protected_raw" | tr '[:upper:]' '[:lower:]')"
 
@@ -77,8 +77,8 @@ if [[ "${#blocked_refs[@]}" -gt 0 ]]; then
     echo "[agent-branch-guard] Push to protected branch blocked."
     echo "[agent-branch-guard] Protected target(s): ${blocked_refs[*]}"
     echo "[agent-branch-guard] Use an agent branch and merge via PR."
-    echo "[agent-branch-guard] Optional VS Code override:"
-    echo "  git config multiagent.allowVscodeProtectedBranchWrites true"
+    echo "[agent-branch-guard] Optional repo hard-block for VS Code protected-branch push:"
+    echo "  git config multiagent.allowVscodeProtectedBranchWrites false"
     echo
     echo "Temporary bypass (not recommended):"
     echo "  ALLOW_PUSH_ON_PROTECTED_BRANCH=1 git push ..."

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -1086,7 +1086,7 @@ test('protect command manages configured protected branches', () => {
   assert.match(result.stdout, /reset to defaults/);
 });
 
-test('pre-commit blocks non-codex VS Code commits on custom protected branches by default', () => {
+test('pre-commit allows non-codex VS Code commits on custom protected branches by default', () => {
   const repoDir = initRepoOnBranch('release');
   seedCommit(repoDir);
 
@@ -1100,11 +1100,10 @@ test('pre-commit blocks non-codex VS Code commits on custom protected branches b
     ALLOW_COMMIT_ON_PROTECTED_BRANCH: '0',
     VSCODE_GIT_IPC_HANDLE: '1',
   });
-  assert.equal(hookResult.status, 1, hookResult.stderr || hookResult.stdout);
-  assert.match(hookResult.stderr, /\[agent-branch-guard\] Direct commits on protected branches are blocked\./);
+  assert.equal(hookResult.status, 0, hookResult.stderr || hookResult.stdout);
 });
 
-test('pre-commit blocks non-codex protected branch commits from VS Code Source Control env by default', () => {
+test('pre-commit allows non-codex protected branch commits from VS Code Source Control env by default', () => {
   const repoDir = initRepo();
   seedCommit(repoDir);
 
@@ -1122,16 +1121,74 @@ test('pre-commit blocks non-codex protected branch commits from VS Code Source C
       VSCODE_IPC_HOOK_CLI: '1',
     },
   );
-  assert.equal(hookResult.status, 1, hookResult.stderr || hookResult.stdout);
-  assert.match(hookResult.stderr, /\[agent-branch-guard\] Direct commits on protected branches are blocked\./);
+  assert.equal(hookResult.status, 0, hookResult.stderr || hookResult.stdout);
 });
 
-test('pre-push blocks non-codex protected branch pushes from VS Code Source Control env by default', () => {
+test('pre-push allows non-codex protected branch pushes from VS Code Source Control env by default', () => {
   const repoDir = initRepoOnBranch('main');
   seedCommit(repoDir);
 
   const setupResult = runNode(['setup', '--target', repoDir, '--no-global-install'], repoDir);
   assert.equal(setupResult.status, 0, setupResult.stderr || setupResult.stdout);
+
+  const hookResult = runCmd(
+    'bash',
+    [
+      '-lc',
+      `printf '%s\\n' 'refs/heads/main 1111111111111111111111111111111111111111 refs/heads/main 0000000000000000000000000000000000000000' | .githooks/pre-push origin origin`,
+    ],
+    repoDir,
+    {
+      VSCODE_GIT_IPC_HANDLE: '1',
+      VSCODE_GIT_ASKPASS_NODE: '1',
+      VSCODE_IPC_HOOK_CLI: '1',
+    },
+  );
+  assert.equal(hookResult.status, 0, hookResult.stderr || hookResult.stdout);
+});
+
+test('pre-commit blocks non-codex protected branch commits from VS Code Source Control env when explicitly disabled', () => {
+  const repoDir = initRepo();
+  seedCommit(repoDir);
+
+  const setupResult = runNode(['setup', '--target', repoDir, '--no-global-install'], repoDir);
+  assert.equal(setupResult.status, 0, setupResult.stderr || setupResult.stdout);
+
+  let configResult = runCmd(
+    'git',
+    ['config', 'multiagent.allowVscodeProtectedBranchWrites', 'false'],
+    repoDir,
+  );
+  assert.equal(configResult.status, 0, configResult.stderr || configResult.stdout);
+
+  const hookResult = runCmd(
+    'bash',
+    ['.githooks/pre-commit'],
+    repoDir,
+    {
+      ALLOW_COMMIT_ON_PROTECTED_BRANCH: '0',
+      VSCODE_GIT_IPC_HANDLE: '1',
+      VSCODE_GIT_ASKPASS_NODE: '1',
+      VSCODE_IPC_HOOK_CLI: '1',
+    },
+  );
+  assert.equal(hookResult.status, 1, hookResult.stderr || hookResult.stdout);
+  assert.match(hookResult.stderr, /\[agent-branch-guard\] Direct commits on protected branches are blocked\./);
+});
+
+test('pre-push blocks non-codex protected branch pushes from VS Code Source Control env when explicitly disabled', () => {
+  const repoDir = initRepoOnBranch('main');
+  seedCommit(repoDir);
+
+  const setupResult = runNode(['setup', '--target', repoDir, '--no-global-install'], repoDir);
+  assert.equal(setupResult.status, 0, setupResult.stderr || setupResult.stdout);
+
+  let configResult = runCmd(
+    'git',
+    ['config', 'multiagent.allowVscodeProtectedBranchWrites', 'false'],
+    repoDir,
+  );
+  assert.equal(configResult.status, 0, configResult.stderr || configResult.stdout);
 
   const hookResult = runCmd(
     'bash',
@@ -1148,64 +1205,6 @@ test('pre-push blocks non-codex protected branch pushes from VS Code Source Cont
   );
   assert.equal(hookResult.status, 1, hookResult.stderr || hookResult.stdout);
   assert.match(hookResult.stderr, /\[agent-branch-guard\] Push to protected branch blocked\./);
-});
-
-test('pre-commit allows non-codex protected branch commits from VS Code Source Control env when explicitly enabled', () => {
-  const repoDir = initRepo();
-  seedCommit(repoDir);
-
-  const setupResult = runNode(['setup', '--target', repoDir, '--no-global-install'], repoDir);
-  assert.equal(setupResult.status, 0, setupResult.stderr || setupResult.stdout);
-
-  let configResult = runCmd(
-    'git',
-    ['config', 'multiagent.allowVscodeProtectedBranchWrites', 'true'],
-    repoDir,
-  );
-  assert.equal(configResult.status, 0, configResult.stderr || configResult.stdout);
-
-  const hookResult = runCmd(
-    'bash',
-    ['.githooks/pre-commit'],
-    repoDir,
-    {
-      ALLOW_COMMIT_ON_PROTECTED_BRANCH: '0',
-      VSCODE_GIT_IPC_HANDLE: '1',
-      VSCODE_GIT_ASKPASS_NODE: '1',
-      VSCODE_IPC_HOOK_CLI: '1',
-    },
-  );
-  assert.equal(hookResult.status, 0, hookResult.stderr || hookResult.stdout);
-});
-
-test('pre-push allows non-codex protected branch pushes from VS Code Source Control env when explicitly enabled', () => {
-  const repoDir = initRepoOnBranch('main');
-  seedCommit(repoDir);
-
-  const setupResult = runNode(['setup', '--target', repoDir, '--no-global-install'], repoDir);
-  assert.equal(setupResult.status, 0, setupResult.stderr || setupResult.stdout);
-
-  let configResult = runCmd(
-    'git',
-    ['config', 'multiagent.allowVscodeProtectedBranchWrites', 'true'],
-    repoDir,
-  );
-  assert.equal(configResult.status, 0, configResult.stderr || configResult.stdout);
-
-  const hookResult = runCmd(
-    'bash',
-    [
-      '-lc',
-      `printf '%s\\n' 'refs/heads/main 1111111111111111111111111111111111111111 refs/heads/main 0000000000000000000000000000000000000000' | .githooks/pre-push origin origin`,
-    ],
-    repoDir,
-    {
-      VSCODE_GIT_IPC_HANDLE: '1',
-      VSCODE_GIT_ASKPASS_NODE: '1',
-      VSCODE_IPC_HOOK_CLI: '1',
-    },
-  );
-  assert.equal(hookResult.status, 0, hookResult.stderr || hookResult.stdout);
 });
 
 test('pre-push blocks codex protected branch pushes even from VS Code Source Control env', () => {


### PR DESCRIPTION
Automated by scripts/agent-branch-finish.sh (PR flow).