### PR TITLE
chore(gitignore): ignore .omc/ runtime state directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ apps/logs/*.log
 .venv
 
 .omx/
+.omc/
 
 # Keep OpenSpec plan workspaces local
 openspec/plan/*


### PR DESCRIPTION
## Summary

- Add `.omc/` to `.gitignore`, right after the existing `.omx/` entry.

## Why

`.omc/state/` holds local OMC agent-replay and subagent-tracking artifacts (`agent-replay-*.jsonl`, `subagent-tracking.json`) that were showing up as untracked in the working tree. They're runtime state, not source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)