### PR TITLE
v6.1.0: enforce primary-checkout immutability (post-checkout hook + AGENTS.md rule)

### DIFF
--- a/bin/multiagent-safety.js
+++ b/bin/multiagent-safety.js
@@ -54,6 +54,7 @@ const TEMPLATE_FILES = [
   'githooks/pre-commit',
   'githooks/pre-push',
   'githooks/post-merge',
+  'githooks/post-checkout',
   'codex/skills/guardex/SKILL.md',
   'codex/skills/guardex-merge-skills-to-dev/SKILL.md',
   'claude/commands/guardex.md',
@@ -97,6 +98,7 @@ const EXECUTABLE_RELATIVE_PATHS = new Set([
   '.githooks/pre-commit',
   '.githooks/pre-push',
   '.githooks/post-merge',
+  '.githooks/post-checkout',
 ]);
 
 const CRITICAL_GUARDRAIL_PATHS = new Set([
@@ -104,6 +106,7 @@ const CRITICAL_GUARDRAIL_PATHS = new Set([
   '.githooks/pre-commit',
   '.githooks/pre-push',
   '.githooks/post-merge',
+  '.githooks/post-checkout',
   'scripts/agent-branch-start.sh',
   'scripts/agent-branch-finish.sh',
   'scripts/agent-worktree-prune.sh',
@@ -131,6 +134,7 @@ const MANAGED_GITIGNORE_PATHS = [
   '.githooks/pre-commit',
   '.githooks/pre-push',
   '.githooks/post-merge',
+  '.githooks/post-checkout',
   'oh-my-codex/',
   '.codex/skills/guardex/SKILL.md',
   '.codex/skills/guardex-merge-skills-to-dev/SKILL.md',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "description": "GuardeX: the Guardian T-Rex for your repo, with hardened multi-agent git guardrails.",
   "license": "MIT",
   "preferGlobal": true,

--- a/templates/AGENTS.multiagent-safety.md
+++ b/templates/AGENTS.multiagent-safety.md
@@ -11,6 +11,7 @@
 - If ownership is unclear or overlaps, stop that edit, post a blocker comment, and let the leader/integrator reassign scope.
 - For git isolation, each agent must start on a dedicated branch via `scripts/agent-branch-start.sh "<task-or-plan>" "<agent-name>"`.
 - In-place branch mode is disallowed: never switch the active local/base checkout to an agent branch.
+- Primary-checkout immutability: agents MUST NOT run `git checkout <branch>` on any repo's primary working tree, including nested repos inside the parent workspace (e.g. tool repos nested under the product repo). Keep each repo's primary checkout on its base/protected branch; use `git worktree add` for feature work. The `.githooks/post-checkout` hook auto-reverts primary-checkout branch switches when an agent session is detected; bypass only with `GUARDEX_ALLOW_PRIMARY_BRANCH_SWITCH=1` when truly intentional.
 - Treat the base branch (`main` or the user's current local base branch) as read-only while the agent branch is active.
 - Agent completion defaults to `scripts/codex-agent.sh`, which auto-finishes the branch (auto-commit changed files, push/create PR, attempt merge, and pull the local base branch after merge).
 - OMX completion policy: when a task is done, the agent must commit the task changes, push the agent branch, and create/update a PR for those changes (via `codex-agent` or `agent-branch-finish`).

--- a/templates/githooks/post-checkout
+++ b/templates/githooks/post-checkout
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# post-checkout <prev_head> <new_head> <branch_checkout_flag>
+branch_checkout="${3:-0}"
+[[ "$branch_checkout" == "1" ]] || exit 0
+
+if [[ "${GUARDEX_ALLOW_PRIMARY_BRANCH_SWITCH:-0}" == "1" ]]; then
+  exit 0
+fi
+
+# Skip in secondary worktrees — only the primary checkout is guarded.
+git_dir_abs="$(cd "$(git rev-parse --git-dir)" && pwd -P)"
+common_dir_abs="$(cd "$(git rev-parse --git-common-dir)" && pwd -P)"
+if [[ "$git_dir_abs" != "$common_dir_abs" ]]; then
+  exit 0
+fi
+
+new_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+# Parse the latest reflog entry; post-checkout writes "checkout: moving from <prev> to <new>".
+prev_branch="$(git reflog -1 HEAD 2>/dev/null | sed -n 's/.*checkout: moving from \([^ ]*\) to .*/\1/p' || true)"
+
+[[ -n "$prev_branch" && -n "$new_branch" && "$prev_branch" != "$new_branch" ]] || exit 0
+
+protected_raw="${GUARDEX_PROTECTED_BRANCHES:-$(git config --get multiagent.protectedBranches || true)}"
+[[ -n "$protected_raw" ]] || protected_raw="dev main master"
+protected_raw="${protected_raw//,/ }"
+
+is_protected() {
+  local branch="$1"
+  for p in $protected_raw; do
+    [[ "$branch" == "$p" ]] && return 0
+  done
+  return 1
+}
+
+# Only guard when moving AWAY from a protected primary branch.
+is_protected "$prev_branch" || exit 0
+
+is_agent=0
+if [[ -n "${CLAUDECODE:-}" \
+   || -n "${CLAUDE_CODE_SESSION_ID:-}" \
+   || -n "${CODEX_THREAD_ID:-}" \
+   || -n "${OMX_SESSION_ID:-}" \
+   || "${CODEX_CI:-0}" == "1" ]]; then
+  is_agent=1
+fi
+
+echo "" >&2
+echo "[agent-primary-branch-guard] Primary checkout switched branches." >&2
+echo "[agent-primary-branch-guard]   from: $prev_branch (protected)" >&2
+echo "[agent-primary-branch-guard]   to:   $new_branch" >&2
+echo "[agent-primary-branch-guard] The primary working tree must stay on its base/protected branch." >&2
+echo "[agent-primary-branch-guard] Use 'git worktree add' (or scripts/agent-branch-start.sh) for feature work." >&2
+
+if [[ "$is_agent" == "1" ]]; then
+  echo "[agent-primary-branch-guard] Agent session detected — reverting to '$prev_branch'." >&2
+  echo "[agent-primary-branch-guard] Bypass with GUARDEX_ALLOW_PRIMARY_BRANCH_SWITCH=1 if truly intentional." >&2
+  if git diff --quiet && git diff --cached --quiet; then
+    GUARDEX_ALLOW_PRIMARY_BRANCH_SWITCH=1 git checkout "$prev_branch" >/dev/null 2>&1 || true
+    echo "[agent-primary-branch-guard] Reverted to '$prev_branch'." >&2
+  else
+    echo "[agent-primary-branch-guard] Working tree dirty — auto-revert skipped." >&2
+    echo "[agent-primary-branch-guard] Fix manually: git stash && git checkout $prev_branch" >&2
+  fi
+else
+  echo "[agent-primary-branch-guard] Bypass with GUARDEX_ALLOW_PRIMARY_BRANCH_SWITCH=1 if intentional." >&2
+fi


### PR DESCRIPTION
Stacked on top of #141 — will rebase onto main once that merges.

## Summary

- **`templates/githooks/post-checkout`** (new): guards the primary working tree. Prints a warning when it switches away from a protected branch; auto-reverts for agent sessions (`CLAUDECODE`, `CODEX_THREAD_ID`, `OMX_SESSION_ID`, etc.) when the tree is clean. No-ops inside secondary `git worktree` checkouts.
- **`templates/AGENTS.multiagent-safety.md`**: adds a primary-checkout-immutability rule so the contract is explicit for humans and agents.
- **`bin/multiagent-safety.js`**: wires `post-checkout` into `TEMPLATE_FILES`, `EXECUTABLE_RELATIVE_PATHS`, `CRITICAL_GUARDRAIL_PATHS`, and `MANAGED_GITIGNORE_PATHS` so `gx doctor` installs it consistently with the other githooks.
- **Bumps to `6.1.0`** (minor — new feature).

## Bypass

`GUARDEX_ALLOW_PRIMARY_BRANCH_SWITCH=1 git checkout <branch>` for intentional primary-checkout switches.

## Test plan

- [x] `main -> feature` in primary checkout: hook warns + auto-reverts (agent env) or warns only (human env).
- [x] Dirty tree: auto-revert skipped; hook prints manual recovery hint.
- [x] Inside `git worktree add` checkout: hook is a no-op (exempt).
- [x] `multiagent.protectedBranches` config honored; falls back to `dev main master`.
- [ ] `gx doctor` installs the hook + chmods +x (will verify after merge + publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)