### PR TITLE
chore(release): bump guardex to 6.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,14 @@ npm pack --dry-run
 
 ## Release notes
 
+### v6.0.1
+
+- Preserve existing repo-owned `AGENTS.md` marker content during `gx setup` / `gx doctor` by default; only rewrite marker blocks when `--force` is explicitly used.
+- Preserve existing `agent:*` package scripts during setup/doctor repairs by default so repo-local command customizations are not silently replaced.
+- Forward `--force` through sandboxed doctor execution so intentional canonical template/script rewrites still work end-to-end.
+- Added regression tests for both preservation behaviors (`setup` + `doctor`).
+- Bumped package version from `6.0.0` to `6.0.1` for the next npm publish.
+
 ### v6.0.0
 
 - **Breaking** — removed the legacy `musafety` bin alias and all `MUSAFETY_*` environment variables. Callers must migrate to the `guardex` / `gx` bins and the `GUARDEX_*` env-var surface.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@imdeadpool/guardex",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "MIT",
       "bin": {
         "guardex": "bin/multiagent-safety.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "GuardeX: the Guardian T-Rex for your repo, with hardened multi-agent git guardrails.",
   "license": "MIT",
   "preferGlobal": true,


### PR DESCRIPTION
Bump @imdeadpool/guardex from 6.0.0 to 6.0.1 and add matching README release notes entry. Verified with node --check, install test, and npm pack --dry-run.