### PR TITLE
feat!: consolidate CLI to 12 commands + trim agent-session templates (v7.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,69 +102,64 @@ gx finish --all
 ## Copy-paste: common commands
 
 ```sh
-# health / safety status
+# health check (default when run with no args)
 gx status
+gx status --strict        # exit non-zero on findings (v6 name: gx scan)
 
-# setup and repair
+# bootstrap, repair, verify — all in one
 gx setup
-gx doctor
-# setup + repair another repo without switching your current repo checkout
+gx setup --repair         # repair only (v6 name: gx fix)
+gx setup --install-only   # scaffold templates, skip global installs (v6 name: gx install)
+gx doctor                 # repair + verify (auto-sandboxes on protected main)
+
+# target another repo without switching your current checkout
 gx setup --target /path/to/repo
 gx doctor --target /path/to/repo
-# optional: from parent folder, generate VS Code workspace view for repo + agent worktrees
-cd /path/to
-gx setup --target ./repo --parent-workspace-view
-# open this in VS Code to manage both base repo and .omx/agent-worktrees
-code ./repo-branches.code-workspace
+# optional VS Code workspace showing repo + agent worktrees
+gx setup --target /path/to/repo --parent-workspace-view
 
 # protected branch management
 gx protect list
 gx protect add release staging
 gx protect remove release
 
-# sync with base branch
+# sync current agent branch with origin/<base>
 gx sync --check
 gx sync
 
-# continuously monitor open PRs targeting current branch and dispatch codex-agent review/merge tasks
-gx review --interval 30
-
-# start both background bots for this repo (review + cleanup)
+# background bots (review monitor + stale cleanup)
 gx agents start
-
-# stop both background bots for this repo
 gx agents stop
+gx agents status
 
-# auto-commit finished agent branches and open/merge PR flow in one pass
-gx finish --all
-
-# cleanup merged agent branches and hide clean stale agent worktrees
-gx cleanup
-
-# run continuous stale-branch cleanup bot (default idle threshold: 10 minutes)
+# per-agent-branch lifecycle
+gx finish --all           # commit + PR + merge every ready agent/* branch
+gx cleanup                # prune merged/stale branches and worktrees
 gx cleanup --watch --interval 60
 
-# scan/report
-gx scan
+# AI-ready setup prompt (paste into Codex/Claude)
+gx prompt                 # full checklist        (v6 name: gx copy-prompt)
+gx prompt --exec          # commands only         (v6 name: gx copy-commands)
+gx prompt --snippet       # AGENTS.md managed block template
+
+# reports
 gx report scorecard --repo github.com/recodeee/guardex
 ```
 
-### Continuous Codex PR monitor (local codex-auth session)
+### v6 → v7 command migration
 
-Run this in your local shell to keep watching PRs targeting the current branch (or `--base <branch>`):
+Five commands were consolidated into flags. Old names still work and print a one-line deprecation notice; they'll be removed in v8.
 
-```sh
-gx review --interval 30
-```
-
-Useful flags:
-
-- `--base main` watch a specific base branch
-- `--only-pr 123` process only one PR
-- `--once` run one polling cycle and exit
-- `--retry-failed` retry failed PRs without waiting for a new head SHA
-
-Note: the monitor dispatches Codex through explicit `--task/--agent/--base` flags for compatibility with both older and newer `scripts/codex-agent.sh` argument parsing.
+| v6 command             | v7 replacement           |
+| ---------------------- | ------------------------ |
+| `gx init`              | `gx setup`               |
+| `gx install`           | `gx setup --install-only`|
+| `gx fix`               | `gx setup --repair`      |
+| `gx scan`              | `gx status --strict`     |
+| `gx copy-prompt`       | `gx prompt`              |
+| `gx copy-commands`     | `gx prompt --exec`       |
+| `gx print-agents-snippet` | `gx prompt --snippet` |
+| `gx review`            | `gx agents start` (runs review + cleanup) |
 
 ### Continuous stale branch cleanup bot
 
@@ -371,6 +366,21 @@ npm pack --dry-run
 ```
 
 ## Release notes
+
+### v7.0.0
+
+- **Breaking (soft).** Consolidated 17 commands into 12 visible commands with flag-based subcommands. Five removed names (`init`, `install`, `fix`, `scan`, `copy-prompt`, `copy-commands`, `print-agents-snippet`, `review`) still work but print a one-line deprecation notice on stderr and will be removed in v8. See the migration table in "Copy-paste: common commands" above.
+- **Token-usage improvements.** Trimmed the auto-installed agent templates that live inside every consumer repo and get loaded into every Claude/Codex session:
+  - `templates/AGENTS.multiagent-safety.md`: 6990 B → 1615 B (−77%)
+  - `templates/codex/skills/guardex/SKILL.md`: 2732 B → 1086 B (−60%)
+  - `templates/claude/commands/guardex.md`: 472 B → 357 B (−24%)
+  - Total: 10194 B → 3058 B per consumer repo (−70%, ~1.5k fewer tokens per agent session).
+
+  The `AI_SETUP_PROMPT` and `AI_SETUP_COMMANDS` constants used by `gx prompt` are now compact checklists, so piping `gx prompt` into a model context is cheaper too.
+- **New `gx prompt` command** replaces three prompt-emitting commands: `gx prompt` (full checklist), `gx prompt --exec` (commands only), `gx prompt --snippet` (AGENTS.md managed-block template).
+- **New flag surface on `gx setup`**: `--install-only` (templates/hooks/locks only), `--repair` (fix drift), plus the existing `--target`, `--parent-workspace-view`, `--dry-run`, etc.
+- **New `gx status --strict`** mirrors the old `gx scan` behavior (exit non-zero on findings).
+- Updated internal `REQUIRED_PACKAGE_SCRIPTS` for consumer `package.json` so `agent:safety:scan` and `agent:safety:fix` helper scripts now invoke the new v7 surface (`gx status --strict`, `gx setup --repair`).
 
 ### v6.0.1
 

--- a/bin/multiagent-safety.js
+++ b/bin/multiagent-safety.js
@@ -163,149 +163,84 @@ const COMMAND_TYPO_ALIASES = new Map([
 const SUGGESTIBLE_COMMANDS = [
   'status',
   'setup',
-  'init',
   'doctor',
-  'review',
   'agents',
   'finish',
   'report',
-  'copy-prompt',
-  'copy-commands',
   'protect',
   'sync',
   'cleanup',
-  'release',
+  'prompt',
+  'help',
+  'version',
+  // deprecated aliases still routable with a warning
+  'init',
   'install',
   'fix',
   'scan',
+  'review',
+  'copy-prompt',
+  'copy-commands',
   'print-agents-snippet',
-  'help',
-  'version',
+  'release',
 ];
 const CLI_COMMAND_DESCRIPTIONS = [
   ['status', 'Show GuardeX CLI + service health without modifying files'],
-  ['setup', 'Install + repair guardrails in a git repo (supports --no-gitignore, --parent-workspace-view)'],
-  ['init', 'Alias of setup (bootstrap + repair guardrails in a git repo)'],
-  ['doctor', 'Repair safety setup drift, then verify repo safety'],
-  ['report', 'Generate security/safety reports (for example: OpenSSF scorecard)'],
-  ['finish', 'Auto-commit completed agent branches, then run PR finish flow'],
-  ['copy-prompt', 'Print the AI-ready setup checklist'],
-  ['copy-commands', 'Print setup checklist as executable commands only'],
+  ['setup', 'Install, repair, and verify guardrails (flags: --repair, --install-only, --target)'],
+  ['doctor', 'Repair drift + verify (auto-sandboxes on protected main)'],
   ['protect', 'Manage protected branches (list/add/remove/set/reset)'],
-  ['sync', 'Check or sync agent branches with origin/<base>'],
-  ['cleanup', 'Cleanup agent branches/worktrees (watch mode defaults to 60-minute idle threshold)'],
+  ['sync', 'Sync agent branches with origin/<base>'],
+  ['finish', 'Commit + PR + merge completed agent branches (--all, --branch)'],
+  ['cleanup', 'Prune merged/stale agent branches and worktrees'],
   ['agents', 'Start/stop repo-scoped review + cleanup bots'],
-  ['install', 'Install templates/locks/hooks without running full setup (supports --no-gitignore)'],
-  ['fix', 'Repair broken or missing guardrail files/config (supports --no-gitignore)'],
-  ['scan', 'Report safety issues and exit non-zero on findings'],
-  ['print-agents-snippet', 'Print the AGENTS.md snippet template'],
-  ['release', 'Publish GuardeX from maintainer release repo'],
+  ['prompt', 'Print AI setup checklist (--exec, --snippet)'],
+  ['report', 'Security/safety reports (e.g. OpenSSF scorecard)'],
   ['help', 'Show this help output'],
   ['version', 'Print GuardeX version'],
 ];
+const DEPRECATED_COMMAND_ALIASES = new Map([
+  ['init', { target: 'setup', hint: 'gx setup' }],
+  ['install', { target: 'setup', hint: 'gx setup --install-only' }],
+  ['fix', { target: 'setup', hint: 'gx setup --repair' }],
+  ['scan', { target: 'status', hint: 'gx status --strict' }],
+  ['copy-prompt', { target: 'prompt', hint: 'gx prompt' }],
+  ['copy-commands', { target: 'prompt', hint: 'gx prompt --exec' }],
+  ['print-agents-snippet', { target: 'prompt', hint: 'gx prompt --snippet' }],
+  ['review', { target: 'agents', hint: 'gx agents start (runs review + cleanup)' }],
+]);
 const AGENT_BOT_DESCRIPTIONS = [
-  ['review', 'Start PR monitor + codex-agent review flow (default interval: 30s)'],
-  ['agents', 'Start/stop both review and cleanup bots for this repo'],
+  ['agents', 'Start/stop review + cleanup bots for this repo'],
 ];
 
-const AI_SETUP_PROMPT = `Use this exact checklist to setup GuardeX (Guardian T-Rex for your repo) in this repository for Codex or Claude.
+const AI_SETUP_PROMPT = `GuardeX (gx) setup checklist for Codex/Claude in this repo.
 
-1) Install (if missing):
-   npm i -g @imdeadpool/guardex
-
-2) Bootstrap safety in this repo:
-   gx setup
-   # alias: gx init
-
-   - Setup detects global OMX/OpenSpec/codex-auth npm packages first.
-   - If one is missing and setup asks for approval, reply explicitly:
-     - y = run: npm i -g oh-my-codex @fission-ai/openspec @imdeadpool/codex-account-switcher (missing ones only)
-     - n = skip global installs
-   - Setup also checks GitHub CLI (gh), required for PR/merge automation.
-   - If gh is missing: install it from https://cli.github.com/ and rerun gx setup.
-
-3) If setup reports warnings/errors, repair + re-check:
-   gx doctor
-
-4) Optional: start continuous PR monitor from this repo:
-   gx review --interval 30
-
-5) Confirm next safe agent workflow commands:
-   bash scripts/codex-agent.sh "task" "agent-name"
-   bash scripts/agent-branch-start.sh "task" "agent-name"
-   python3 scripts/agent-file-locks.py claim --branch "$(git rev-parse --abbrev-ref HEAD)" <file...>
-   bash scripts/agent-branch-finish.sh --branch "$(git rev-parse --abbrev-ref HEAD)" --base dev --via-pr --wait-for-merge
-   - For every new user message/task, repeat the same cycle:
-     start isolated agent branch/worktree -> claim file locks -> implement/verify ->
-     finish via PR/merge cleanup into dev with scripts/agent-branch-finish.sh.
-   - Finished branches stay available by default for audit/follow-up.
-     Remove them explicitly when done:
-     gx cleanup --branch "$(git rev-parse --abbrev-ref HEAD)"
-   - To finalize all completed agent branches in one pass:
-     gx finish --all
-
-6) OpenSpec default change flow (core profile):
-   /opsx:propose <change-name>
-   /opsx:apply
-   /opsx:archive
-   - Full guide: docs/openspec-getting-started.md
-
-7) Optional: enable expanded OpenSpec workflow commands:
-   openspec config profile <profile-name>
-   openspec update
-   - Expanded path: /opsx:new -> /opsx:ff or /opsx:continue -> /opsx:apply -> /opsx:verify -> /opsx:archive
-
-8) Optional: create OpenSpec planning workspace:
-   bash scripts/openspec/init-plan-workspace.sh "<plan-slug>"
-
-9) Optional: protect extra branches:
-   gx protect add release staging
-
-10) Optional: sync your current agent branch with latest base branch:
-   gx sync --check
-   gx sync
-
-11) Optional (GitHub remote cleanup): enable:
-   Settings -> General -> Pull Requests -> Automatically delete head branches
-
-12) Optional (fork sync with Pull app):
-   cp .github/pull.yml.example .github/pull.yml
-   # then edit .github/pull.yml:
-   # - set rules[].base to your fork branch (main/master/dev)
-   # - set rules[].upstream to upstream-owner:branch
-   # install app: https://github.com/apps/pull
-   # validate config: https://pull.git.ci/check/<owner>/<repo>
-
-13) Optional (PR review bot with cr-gpt GitHub App):
-   - install app: https://github.com/apps/cr-gpt
-   - in GitHub repo Settings -> Secrets and variables -> Actions -> Variables:
-     add OPENAI_API_KEY (your API key)
-   - the app reviews new/updated pull requests automatically
-
-14) Optional: test PR review action workflow
-   - gx setup installs .github/workflows/cr.yml
-   - open or update a PR
-   - check Actions -> "Code Review" run logs + PR timeline comments
+1) Install:         npm i -g @imdeadpool/guardex && gh --version
+2) Bootstrap:       gx setup         # installs hooks/templates + verifies; prompts Y/N for global OMX/OpenSpec/codex-auth
+3) If degraded:     gx doctor        # repair + re-verify
+4) Per task:        bash scripts/codex-agent.sh "<task>" "<agent>"
+                    # or manual:
+                    #   bash scripts/agent-branch-start.sh "<task>" "<agent>"
+                    #   python3 scripts/agent-file-locks.py claim --branch "$(git rev-parse --abbrev-ref HEAD)" <file...>
+                    #   bash scripts/agent-branch-finish.sh --branch "$(git rev-parse --abbrev-ref HEAD)" --via-pr --wait-for-merge
+5) Finalize all:    gx finish --all
+6) Cleanup:         gx cleanup
+7) OpenSpec:        /opsx:propose -> /opsx:apply -> /opsx:archive   (see docs/openspec-getting-started.md)
+8) Protect:         gx protect add release staging                  (optional)
+9) Sync:            gx sync --check && gx sync                      (optional; rebase onto base)
+10) Fork sync:      cp .github/pull.yml.example .github/pull.yml    (optional; install https://github.com/apps/pull)
+11) PR review bot:  install https://github.com/apps/cr-gpt + set OPENAI_API_KEY in Actions variables (uses .github/workflows/cr.yml)
+12) GitHub repo:    enable Settings -> PRs -> Automatically delete head branches
 `;
 
 const AI_SETUP_COMMANDS = `npm i -g @imdeadpool/guardex
 gh --version
 gx setup
 gx doctor
-gx review --interval 30
-bash scripts/codex-agent.sh "task" "agent-name"
-bash scripts/agent-branch-start.sh "task" "agent-name"
-python3 scripts/agent-file-locks.py claim --branch "$(git rev-parse --abbrev-ref HEAD)" <file...>
-bash scripts/agent-branch-finish.sh --branch "$(git rev-parse --abbrev-ref HEAD)" --base dev --via-pr --wait-for-merge
+bash scripts/codex-agent.sh "<task>" "<agent>"
 gx finish --all
-gx cleanup --branch "$(git rev-parse --abbrev-ref HEAD)"
-bash scripts/openspec/init-plan-workspace.sh "<plan-slug>"
-openspec config profile <profile-name>
-openspec update
+gx cleanup
 gx protect add release staging
-gx sync --check
 gx sync
-cp .github/pull.yml.example .github/pull.yml
 `;
 
 const SCORECARD_RISK_BY_CHECK = {
@@ -439,19 +374,12 @@ AGENT BOT
 ${agentBotCatalogLines().join('\n')}
 
 NOTES
-  - Running ${TOOL_NAME} with no command defaults to: ${SHORT_TOOL_NAME} status
-  - Short alias: ${SHORT_TOOL_NAME}
-  - ${SHORT_TOOL_NAME} init is an alias of ${SHORT_TOOL_NAME} setup
-  - ${TOOL_NAME} setup asks for Y/N approval before global installs
-  - ${TOOL_NAME} setup checks GitHub CLI (gh) and prints install guidance if missing
-  - For other repos: ${SHORT_TOOL_NAME} setup --target <repo-path> then ${SHORT_TOOL_NAME} doctor --target <repo-path>
-  - Optional parent-folder Source Control view: ${SHORT_TOOL_NAME} setup --target <repo-path> --parent-workspace-view
-  - In initialized repos, setup/install/fix block in-place writes on protected main by default
-  - setup/doctor auto-finish clean pending agent/* branches via PR flow into the current local base branch
-  - doctor auto-runs in a sandbox agent branch/worktree on protected main and tries auto-finish PR flow
-  - agent-branch-finish merges by default and keeps agent branches/worktrees until explicit cleanup
-  - use '${SHORT_TOOL_NAME} cleanup' to remove merged agent branches/worktrees (optionally remote refs too)
-  - Legacy command aliases are still supported: ${LEGACY_NAMES.join(', ')}`);
+  - No command = ${SHORT_TOOL_NAME} status. ${SHORT_TOOL_NAME} init is an alias of ${SHORT_TOOL_NAME} setup.
+  - Global installs need Y/N approval; GitHub CLI (gh) is required for PR automation.
+  - Target another repo: ${SHORT_TOOL_NAME} <cmd> --target <repo-path>.
+  - On protected main, setup/install/fix/doctor auto-sandbox via agent branch + PR flow.
+  - Run '${SHORT_TOOL_NAME} cleanup' to prune merged agent branches/worktrees.
+  - Legacy aliases: ${LEGACY_NAMES.join(', ')}.`);
 
   if (outsideGitRepo) {
     console.log(`
@@ -4478,7 +4406,7 @@ function setup(rawArgs) {
 
   if (scanResult.errors === 0 && scanResult.warnings === 0) {
     console.log(`[${TOOL_NAME}] ✅ Setup complete.`);
-    console.log(`[${TOOL_NAME}] Copy AI setup prompt with: ${SHORT_TOOL_NAME} copy-prompt`);
+    console.log(`[${TOOL_NAME}] Copy AI setup prompt with: ${SHORT_TOOL_NAME} prompt`);
     console.log(
       `[${TOOL_NAME}] OpenSpec core workflow: /opsx:propose -> /opsx:apply -> /opsx:archive`,
     );
@@ -4785,6 +4713,31 @@ function copyPrompt() {
 function copyCommands() {
   process.stdout.write(AI_SETUP_COMMANDS);
   process.exitCode = 0;
+}
+
+function prompt(rawArgs) {
+  const args = Array.isArray(rawArgs) ? rawArgs : [];
+  let variant = 'prompt';
+  for (const arg of args) {
+    if (arg === '--exec' || arg === '--commands') variant = 'exec';
+    else if (arg === '--snippet' || arg === '--agents') variant = 'snippet';
+    else if (arg === '--prompt' || arg === '--full') variant = 'prompt';
+    else if (arg === '-h' || arg === '--help') variant = 'help';
+    else throw new Error(`Unknown option: ${arg}`);
+  }
+  if (variant === 'help') {
+    console.log(
+      `${SHORT_TOOL_NAME} prompt commands:\n` +
+      `  ${SHORT_TOOL_NAME} prompt           Print AI setup checklist\n` +
+      `  ${SHORT_TOOL_NAME} prompt --exec    Print setup commands only (shell-ready)\n` +
+      `  ${SHORT_TOOL_NAME} prompt --snippet Print the AGENTS.md managed-block template`,
+    );
+    process.exitCode = 0;
+    return;
+  }
+  if (variant === 'exec') return copyCommands();
+  if (variant === 'snippet') return printAgentsSnippet();
+  return copyPrompt();
 }
 
 function cleanup(rawArgs) {
@@ -5265,6 +5218,29 @@ function normalizeCommandOrThrow(command) {
   return command;
 }
 
+function warnDeprecatedAlias(aliasName) {
+  const entry = DEPRECATED_COMMAND_ALIASES.get(aliasName);
+  if (!entry) return;
+  console.error(
+    `[${TOOL_NAME}] '${aliasName}' is deprecated and will be removed in a future major release. ` +
+    `Use: ${entry.hint}`,
+  );
+}
+
+function extractFlag(args, ...names) {
+  const flagSet = new Set(names);
+  let found = false;
+  const remaining = [];
+  for (const arg of args) {
+    if (flagSet.has(arg)) {
+      found = true;
+    } else {
+      remaining.push(arg);
+    }
+  }
+  return { found, remaining };
+}
+
 function main() {
   const args = process.argv.slice(2);
 
@@ -5288,90 +5264,42 @@ function main() {
     return;
   }
 
+  // Deprecated direct aliases — route to new surface and warn once.
+  if (DEPRECATED_COMMAND_ALIASES.has(command)) {
+    warnDeprecatedAlias(command);
+    if (command === 'init') return setup(rest);
+    if (command === 'install') return install(rest);
+    if (command === 'fix') return fix(rest);
+    if (command === 'scan') return scan(rest);
+    if (command === 'copy-prompt') return copyPrompt();
+    if (command === 'copy-commands') return copyCommands();
+    if (command === 'print-agents-snippet') return printAgentsSnippet();
+    if (command === 'review') return review(rest);
+  }
+
   if (command === 'status') {
-    status(rest);
-    return;
+    const { found: strict, remaining } = extractFlag(rest, '--strict');
+    if (strict) return scan(remaining);
+    return status(remaining);
   }
 
-  if (command === 'setup' || command === 'init') {
-    setup(rest);
-    return;
+  if (command === 'setup') {
+    const installOnly = extractFlag(rest, '--install-only', '--only-install');
+    if (installOnly.found) return install(installOnly.remaining);
+    const repairOnly = extractFlag(installOnly.remaining, '--repair', '--fix-only');
+    if (repairOnly.found) return fix(repairOnly.remaining);
+    return setup(repairOnly.remaining);
   }
 
-  if (command === 'doctor') {
-    doctor(rest);
-    return;
-  }
-
-  if (command === 'review') {
-    review(rest);
-    return;
-  }
-
-  if (command === 'agents') {
-    agents(rest);
-    return;
-  }
-
-  if (command === 'finish') {
-    finish(rest);
-    return;
-  }
-
-  if (command === 'report') {
-    report(rest);
-    return;
-  }
-
-  if (command === 'copy-prompt') {
-    copyPrompt();
-    return;
-  }
-
-  if (command === 'copy-commands') {
-    copyCommands();
-    return;
-  }
-
-  if (command === 'protect') {
-    protect(rest);
-    return;
-  }
-
-  if (command === 'sync') {
-    sync(rest);
-    return;
-  }
-
-  if (command === 'cleanup') {
-    cleanup(rest);
-    return;
-  }
-
-  if (command === 'release') {
-    release(rest);
-    return;
-  }
-
-  if (command === 'install') {
-    install(rest);
-    return;
-  }
-
-  if (command === 'fix') {
-    fix(rest);
-    return;
-  }
-
-  if (command === 'scan') {
-    scan(rest);
-    return;
-  }
-
-  if (command === 'print-agents-snippet') {
-    printAgentsSnippet();
-    return;
-  }
+  if (command === 'prompt') return prompt(rest);
+  if (command === 'doctor') return doctor(rest);
+  if (command === 'agents') return agents(rest);
+  if (command === 'finish') return finish(rest);
+  if (command === 'report') return report(rest);
+  if (command === 'protect') return protect(rest);
+  if (command === 'sync') return sync(rest);
+  if (command === 'cleanup') return cleanup(rest);
+  if (command === 'release') return release(rest);
 
   const suggestion = maybeSuggestCommand(command);
   if (suggestion) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "6.0.1",
+  "version": "7.0.0",
   "description": "GuardeX: the Guardian T-Rex for your repo, with hardened multi-agent git guardrails.",
   "license": "MIT",
   "preferGlobal": true,
@@ -25,8 +25,8 @@
     "agent:branch:sync": "gx sync",
     "agent:branch:sync:check": "gx sync --check",
     "agent:safety:setup": "gx setup",
-    "agent:safety:scan": "gx scan",
-    "agent:safety:fix": "gx fix",
+    "agent:safety:scan": "gx status --strict",
+    "agent:safety:fix": "gx setup --repair",
     "agent:safety:doctor": "gx doctor",
     "agent:review:watch": "bash ./scripts/review-bot-watch.sh",
     "agent:finish": "gx finish --all"

--- a/templates/AGENTS.multiagent-safety.md
+++ b/templates/AGENTS.multiagent-safety.md
@@ -1,124 +1,19 @@
 <!-- multiagent-safety:START -->
-## Multi-Agent Execution Contract (multiagent-safety)
+## Multi-Agent Safety Contract
 
-0. Session plan comment + read gate (required)
+**Isolation.** Every task runs on a dedicated `agent/*` branch + worktree. Start with `scripts/agent-branch-start.sh "<task>" "<agent-name>"`. Treat the base branch (`main`/`dev`) as read-only while an agent branch is active.
 
-- Before editing, each agent must post a short session comment/handoff note that includes:
-  - plan/change name (or checkpoint id),
-  - owned files/scope,
-  - intended action.
-- Before deleting/replacing code, each agent must read the latest session comments/handoffs first and confirm the target code is in their owned scope.
-- If ownership is unclear or overlaps, stop that edit, post a blocker comment, and let the leader/integrator reassign scope.
-- For git isolation, each agent must start on a dedicated branch via `scripts/agent-branch-start.sh "<task-or-plan>" "<agent-name>"`.
-- Treat the base branch (`main` or the user's current local base branch) as read-only while the agent branch is active.
-- Agent completion defaults to `scripts/codex-agent.sh`, which auto-finishes the branch (auto-commit changed files, push/create PR, attempt merge, and pull the local base branch after merge).
-- Auto-finish now waits for required checks/merge and then cleans merged sandbox branch/worktree by default.
-- Cleanup for merged `agent/*` branches is mandatory; `agent-branch-finish` must not report completion while local/remote refs or sandbox worktree cleanup is still pending.
-- Cleanup automation must be branch-scoped: do not prune other agents' current worktrees during finish; only the source branch sandbox may be auto-removed.
-- Other agent worktrees may be pruned only when they are explicitly targeted or have no active local changes.
-- If codex-agent auto-finish cannot complete, immediately run `scripts/agent-branch-finish.sh --branch "<agent-branch>" --via-pr --wait-for-merge` and keep the branch open until checks/review pass.
-- If merge/rebase conflicts block auto-finish, run a conflict-resolution review pass in that sandbox branch, then rerun `agent-branch-finish.sh --via-pr` until merged.
-- Completion is not valid until these are true: commit exists on the agent branch, branch is pushed to `origin`, and PR/merge status is produced by `agent-branch-finish.sh` or `codex-agent`.
-- Completion report must include the PR URL and explicit merge state (`OPEN`/`MERGED`); without this, the task is not complete.
-- For every new task, if an assigned agent sub-branch/worktree is already open, continue in that sub-branch; otherwise create a fresh one from the current local base snapshot with `scripts/agent-branch-start.sh`.
-- Never implement directly on the local/base branch checkout; keep it unchanged and perform all edits in the agent sub-branch/worktree.
-- Agent worktree startup must preserve the primary local checkout branch exactly as-is; branch switching is allowed only inside the agent worktree.
-- If the change publishes or bumps a version, the same change must also update release notes/changelog entries.
+**Ownership.** Before editing, claim files: `scripts/agent-file-locks.py claim --branch "<agent-branch>" <file...>`. Before deleting, confirm the path is in your claim. Don't edit outside your scope unless reassigned.
 
-1. Explicit ownership before edits
+**Handoff gate.** Post a one-line handoff note (plan/change, owned scope, intended action) before editing. Re-read the latest handoffs before replacing others' code.
 
-- Assign each agent clear file/module ownership.
-- Do not edit files outside your assigned scope unless the leader reassigns ownership.
+**Completion.** Finish with `scripts/agent-branch-finish.sh --branch "<agent-branch>" --via-pr --wait-for-merge --cleanup` (or `gx finish --all`). Task is only complete when: commit pushed, PR URL recorded, state = `MERGED`, sandbox worktree pruned. If anything blocks, append a `BLOCKED:` note and stop — don't half-finish.
 
-2. Preserve parallel safety
+**Parallel safety.** Assume other agents edit nearby. Never revert unrelated changes. Report conflicts in the handoff.
 
-- Assume other agents are editing nearby code concurrently.
-- Never revert unrelated changes authored by others.
-- If another change conflicts with your approach, adapt and report the conflict in handoff.
+**Reporting.** Every completion handoff includes: files changed, behavior touched, verification commands + results, risks/follow-ups.
 
-3. Verify before completion
+**OpenSpec (when change-driven).** Keep `openspec/changes/<slug>/tasks.md` checkboxes current during work, not batched at the end. Verify specs with `openspec validate --specs` before archive. Don't archive unverified.
 
-- Run required local checks for the area you changed.
-- Do not mark work complete without command output evidence.
-
-4. Required handoff format (every agent)
-
-- Files changed
-- Behavior touched
-- Verification commands + results
-- Risks / follow-ups
-
-## OpenSpec Multi-Codex Change Management (owner + joined Codexes)
-
-Use this checklist for active OpenSpec changes when one owner Codex may receive help from joined Codexes (including other worktree Codexes).
-
-Joined helper branches that merge into another `agent/*` branch are documentation-exempt assist lanes; they implement assigned scope only and report handoff evidence back to the owner branch artifacts.
-
-Checkpoint discipline (required): update the active change `tasks.md` during work, checkpoint-by-checkpoint, and keep checkbox state synchronized with current progress.
-
-**Definition of Done (applies to every active change):** the change is complete only when every checkbox below is checked AND the agent branch reaches `MERGED` state on `origin` with the PR URL + state recorded in the completion handoff. If verification halts (test failure, conflict, ambiguous result), append a `BLOCKED:` line under the cleanup section explaining the blocker and **STOP** — do not silently skip the cleanup pipeline. Surfacing a blocker is preferred over a half-finished completion.
-
-## 1. Specification
-
-- [ ] 1.1 Finalize proposal scope and acceptance criteria for the active change.
-- [ ] 1.2 Define normative requirements in the change spec (`specs/<capability>/spec.md`).
-
-## 2. Implementation
-
-- [ ] 2.1 Implement scoped behavior changes.
-- [ ] 2.2 Add/update focused regression coverage.
-
-## 3. Verification
-
-- [ ] 3.1 Run targeted project verification commands.
-- [ ] 3.2 Run `openspec validate <change-slug> --type change --strict`.
-- [ ] 3.3 Run `openspec validate --specs`.
-
-## 4. Collaboration (only when another Codex joins)
-
-- [ ] 4.1 Owner Codex records each joined Codex (branch/worktree + scope) before accepting work.
-- [ ] 4.2 Joined Codexes may review, propose solution tasks, and implement only within assigned scope.
-- [ ] 4.3 Owner Codex must acknowledge joined outputs (accept/revise/reject) before moving to cleanup.
-- [ ] 4.4 If no Codex joined, mark this section `N/A` and continue.
-
-## 5. Cleanup (mandatory; run before claiming completion)
-
-- [ ] 5.1 Run the cleanup pipeline: `bash scripts/agent-branch-finish.sh --branch <agent-branch> --base dev --via-pr --wait-for-merge --cleanup`. This handles commit → push → PR create → merge wait → worktree prune in one invocation.
-- [ ] 5.2 Record the PR URL and final merge state (`MERGED`) in the completion handoff.
-- [ ] 5.3 Confirm the sandbox worktree is gone (`git worktree list` no longer shows the agent path; `git branch -a` shows no surviving local/remote refs for the branch).
-
-For change specs that need explicit baseline requirement wording, use this pattern:
-
-## ADDED Requirements
-
-### Requirement: <change-slug> behavior
-The system SHALL enforce <change-slug> behavior as defined by this change.
-
-#### Scenario: Baseline acceptance
-- **WHEN** <change-slug> behavior is exercised
-- **THEN** the expected outcome is produced
-- **AND** regressions are covered by tests.
-
-## OpenSpec Plan Workspace (recommended)
-
-When work needs a durable planning phase, scaffold a plan workspace before implementation:
-
-```bash
-bash scripts/openspec/init-plan-workspace.sh "<plan-slug>"
-```
-
-Expected shape:
-
-```text
-openspec/plan/<plan-slug>/
-  summary.md
-  checkpoints.md
-  planner/plan.md
-  planner/tasks.md
-  architect/tasks.md
-  critic/tasks.md
-  executor/tasks.md
-  writer/tasks.md
-  verifier/tasks.md
-```
+**Version bumps.** If a change bumps a published version, the same PR updates release notes/changelog.
 <!-- multiagent-safety:END -->

--- a/templates/claude/commands/guardex.md
+++ b/templates/claude/commands/guardex.md
@@ -1,18 +1,12 @@
 # /guardex
 
-Run a GuardeX check-and-repair workflow for the current repository.
+Run a GuardeX check-and-repair for the current repo.
 
 ## Steps
 
-1. Run `gx status`.
-2. If status is degraded, run `gx doctor`.
-3. If still degraded, run `gx scan` and summarize each finding with a fix.
-4. Report final verdict as one of:
-   - `Repo is guarded`
-   - `Repo is not guarded` (include blockers)
+1. `gx status` — if green, stop.
+2. If degraded, `gx doctor`.
+3. If still degraded, `gx status --strict` and summarize each finding with a fix.
+4. Report verdict: `Repo is guarded` or `Repo is not guarded` (list blockers).
 
-## Style
-
-- Keep output short and operational.
-- Include exact commands you executed.
-- Prefer concrete next actions over generic advice.
+Keep output short, include the exact commands you ran.

--- a/templates/codex/skills/guardex/SKILL.md
+++ b/templates/codex/skills/guardex/SKILL.md
@@ -1,89 +1,41 @@
 ---
 name: guardex
-description: "Use when you need to check, repair, or bootstrap multi-agent safety guardrails in this repository."
+description: "Check, repair, or bootstrap multi-agent safety guardrails in this repository."
 ---
 
 # GuardeX (Codex skill)
 
-Use this skill whenever branch safety, lock ownership, or guardrail setup may be broken.
+Use when branch safety, lock ownership, or guardrail setup may be broken.
 
 ## Fast path
 
-1. Run `gx status`.
-2. If repo safety is degraded, run `gx doctor`.
-3. If issues remain, run `gx scan` and address the findings.
+1. `gx status` — one-glance health check.
+2. If degraded, `gx doctor` — repair + verify in one pass.
+3. If issues remain, `gx status --strict` and address each finding.
 
-## Setup path
-
-If guardrails are missing entirely, run:
+## Bootstrap (missing guardrails)
 
 ```sh
-gx setup
-# alias
-gx init
+gx setup      # install + repair + verify
+gx status     # confirm green
 ```
 
-Then verify:
+## Notes
+
+- Isolation: `scripts/codex-agent.sh "<task>" "<agent>"` is the one-command sandbox start/finish loop.
+- Completion: auto-finish keeps the branch until explicit `gx cleanup`.
+- Never bypass protected-branch safeguards.
+
+## Bulk finish
 
 ```sh
-gx status
-gx scan
+gx finish --all                # commit + PR + merge all ready agent/* branches
+gx cleanup                     # prune merged/stale branches and worktrees
 ```
 
-## Operator notes
-
-- Prefer `gx doctor` for one-step repair + verification.
-- Keep agent work isolated (`agent/*` branches + lock claims).
-- For every new user message/task, restart the full loop on a fresh agent branch/worktree.
-- For one-command Codex sandbox startup, use `bash scripts/codex-agent.sh "<task>" "<agent-name>"`.
-- `scripts/codex-agent.sh` auto-syncs the sandbox branch against base before each task and auto-finishes merge/PR flow after Codex exits.
-- Auto-finish keeps the branch/worktree by default; remove merged branches explicitly with `gx cleanup` (or `gx cleanup --branch "<agent-branch>"`).
-- For skill-file-only merges into the local base branch (`dev` by default), use `$guardex-merge-skills-to-dev`.
-- Do not bypass protected branch safeguards unless explicitly required.
-
-## Bulk merge runbook (changed agent branches)
-
-Use this when a repo has many `agent/*` branches/worktrees with pending changes and you need them merged into the base branch quickly.
-
-1. Confirm base and guardrails are healthy:
-
-```sh
-git status --short --branch
-git pull --ff-only origin "$(git config --get multiagent.baseBranch || echo dev)"
-gx scan
-```
-
-2. Run bulk finish first:
-
-```sh
-gx finish --all
-```
-
-3. If a branch fails with `already used by worktree` or stale rebase hints, clear the stale state in that worktree, then retry targeted finish:
+If a branch fails with stale rebase/worktree state:
 
 ```sh
 git -C "<worktree>" rebase --abort || true
-gx finish --branch "<agent-branch>" --base "$(git config --get multiagent.baseBranch || echo dev)" --no-wait-for-merge --cleanup
-```
-
-4. If `gh pr merge` exits non-zero due local branch deletion but PR is already merged, treat it as merged and verify with:
-
-```sh
-gh pr view "<pr-number>" --json state,mergedAt,url
-```
-
-5. If a branch is still ahead of base with no open PR, create and merge a follow-up PR manually:
-
-```sh
-gh pr create --base "<base-branch>" --head "<agent-branch>" --title "Auto-finish: <agent-branch>" --body "Follow-up merge for pending branch commits."
-gh pr merge "<pr-number>" --squash --delete-branch
-```
-
-6. Final verification:
-
-```sh
-gh pr list --state open --search "head:agent/ base:<base-branch>"
-git pull --ff-only origin "<base-branch>"
-gx cleanup
-gx scan
+gx finish --branch "<agent-branch>" --cleanup
 ```

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -1456,9 +1456,8 @@ test('default invocation runs non-mutating status output', () => {
   assert.match(result.stdout, /COMMANDS\n\s+status\s+Show GuardeX CLI \+ service health without modifying files/);
   assert.match(
     result.stdout,
-    /AGENT BOT\n\s+review\s+Start PR monitor \+ codex-agent review flow \(default interval: 30s\)/,
+    /AGENT BOT\n\s+agents\s+Start\/stop review \+ cleanup bots for this repo/,
   );
-  assert.match(result.stdout, /AGENT BOT[\s\S]*\n\s+agents\s+Start\/stop both review and cleanup bots for this repo/);
   assert.equal(fs.existsSync(path.join(repoDir, '.githooks', 'pre-commit')), false);
 });
 
@@ -3373,44 +3372,53 @@ exit 1
   assert.match(remediation, /Verification loop/);
 });
 
-test('copy-prompt outputs AI setup instructions', () => {
+test('prompt outputs AI setup instructions', () => {
+  const repoDir = initRepo();
+  const result = runNode(['prompt'], repoDir);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /npm i -g @imdeadpool\/guardex/);
+  assert.match(result.stdout, /GuardeX \(gx\) setup checklist/);
+  assert.match(result.stdout, /gx setup/);
+  assert.match(result.stdout, /gx doctor/);
+  assert.match(result.stdout, /codex-agent\.sh/);
+  assert.match(result.stdout, /scripts\/agent-file-locks\.py claim/);
+  assert.match(result.stdout, /gx finish --all/);
+  assert.match(result.stdout, /\/opsx:propose/);
+  assert.match(result.stdout, /https:\/\/github\.com\/apps\/pull/);
+  assert.match(result.stdout, /https:\/\/github\.com\/apps\/cr-gpt/);
+  assert.match(result.stdout, /OPENAI_API_KEY/);
+});
+
+test('prompt --exec outputs command-only checklist', () => {
+  const repoDir = initRepo();
+  const result = runNode(['prompt', '--exec'], repoDir);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /^npm i -g @imdeadpool\/guardex/m);
+  assert.match(result.stdout, /^gh --version/m);
+  assert.match(result.stdout, /^gx setup$/m);
+  assert.match(result.stdout, /^gx doctor$/m);
+  assert.match(result.stdout, /codex-agent\.sh/);
+  assert.match(result.stdout, /^gx finish --all$/m);
+  assert.match(result.stdout, /^gx cleanup$/m);
+  assert.doesNotMatch(result.stdout, /GuardeX \(gx\) setup checklist/);
+});
+
+test('deprecated copy-prompt alias still works and warns', () => {
   const repoDir = initRepo();
   const result = runNode(['copy-prompt'], repoDir);
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  assert.match(result.stdout, /npm i -g @imdeadpool\/guardex/);
-  assert.match(
-    result.stdout,
-    /npm i -g oh-my-codex @fission-ai\/openspec @imdeadpool\/codex-account-switcher/,
-  );
-  assert.match(result.stdout, /gx setup/);
-  assert.match(result.stdout, /gx init/);
-  assert.match(result.stdout, /Codex or Claude/);
-  assert.match(result.stdout, /OpenSpec default change flow \(core profile\)/);
-  assert.match(result.stdout, /\/opsx:propose <change-name>/);
-  assert.match(result.stdout, /openspec config profile <profile-name>/);
-  assert.match(result.stdout, /fork sync with Pull app/);
-  assert.match(result.stdout, /https:\/\/github.com\/apps\/pull/);
-  assert.match(result.stdout, /https:\/\/github.com\/apps\/cr-gpt/);
-  assert.match(result.stdout, /OPENAI_API_KEY/);
-  assert.match(result.stdout, /\.github\/workflows\/cr\.yml/);
-  assert.match(result.stdout, /scripts\/agent-file-locks.py claim/);
-  assert.match(result.stdout, /For every new user message\/task, repeat the same cycle/);
+  assert.match(result.stdout, /GuardeX \(gx\) setup checklist/);
+  assert.match(result.stderr, /'copy-prompt' is deprecated/);
+  assert.match(result.stderr, /gx prompt/);
 });
 
-test('copy-commands outputs command-only checklist', () => {
+test('deprecated copy-commands alias still works and warns', () => {
   const repoDir = initRepo();
   const result = runNode(['copy-commands'], repoDir);
   assert.equal(result.status, 0, result.stderr || result.stdout);
   assert.match(result.stdout, /^npm i -g @imdeadpool\/guardex/m);
-  assert.match(result.stdout, /^gh --version/m);
-  assert.match(result.stdout, /gx setup/);
-  assert.match(result.stdout, /gx doctor/);
-  assert.match(result.stdout, /scripts\/agent-file-locks.py claim/);
-  assert.match(result.stdout, /^openspec config profile <profile-name>$/m);
-  assert.match(result.stdout, /^openspec update$/m);
-  assert.match(result.stdout, /^cp \.github\/pull\.yml\.example \.github\/pull\.yml$/m);
-  assert.match(result.stdout, /gx sync --check/);
-  assert.doesNotMatch(result.stdout, /Use this exact checklist/);
+  assert.match(result.stderr, /'copy-commands' is deprecated/);
+  assert.match(result.stderr, /gx prompt --exec/);
 });
 
 test('setup dry-run accepts explicit global install approval flags', () => {


### PR DESCRIPTION
## Summary

- Consolidate 17 top-level commands into 12 with flag-based subcommands; removed names remain as hidden deprecation aliases (one-line stderr warning) and are scheduled for removal in v8.
- Trim the auto-installed agent-session templates by ~70% (10,194 B → 3,058 B per consumer repo, ~1.5k fewer tokens per downstream Claude/Codex session).
- New surface: \`gx prompt [--exec|--snippet]\`, \`gx setup [--repair|--install-only]\`, \`gx status [--strict]\`.
- Bump to **7.0.0** with release notes.

### Command migration

| v6 command                | v7 replacement              |
| ------------------------- | --------------------------- |
| \`gx init\`                 | \`gx setup\`                  |
| \`gx install\`              | \`gx setup --install-only\`   |
| \`gx fix\`                  | \`gx setup --repair\`         |
| \`gx scan\`                 | \`gx status --strict\`        |
| \`gx copy-prompt\`          | \`gx prompt\`                 |
| \`gx copy-commands\`        | \`gx prompt --exec\`          |
| \`gx print-agents-snippet\` | \`gx prompt --snippet\`       |
| \`gx review\`               | \`gx agents start\`           |

### Template trims (per consumer repo, auto-loaded every agent session)

| File                                         | Before  | After   | Δ     |
| -------------------------------------------- | ------- | ------- | ----- |
| \`templates/AGENTS.multiagent-safety.md\`      | 6990 B  | 1615 B  | −77%  |
| \`templates/codex/skills/guardex/SKILL.md\`    | 2732 B  | 1086 B  | −60%  |
| \`templates/claude/commands/guardex.md\`       |  472 B  |  357 B  | −24%  |
| **Total**                                    | 10194 B | 3058 B  | **−70%** |

## Test plan

- [x] \`node --check bin/multiagent-safety.js\`
- [x] \`node bin/multiagent-safety.js --help\` renders 12-command surface
- [x] Deprecated aliases (\`copy-prompt\`, \`scan\`, \`install\`, \`fix\`, \`init\`, \`review\`) all still route and emit a one-line stderr warning
- [x] \`gx prompt\`, \`gx prompt --exec\`, \`gx prompt --snippet\` — all three variants verified
- [x] \`npm test\`: 118 tests, 99 passing, 19 pre-existing baseline failures (zero new regressions; +2 new deprecation-alias tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)