### PR TITLE
feat(setup): monorepo-aware recursive install for gx setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ gx doctor --target /path/to/repo
 # optional VS Code workspace showing repo + agent worktrees
 gx setup --target /path/to/repo --parent-workspace-view
 
+# monorepo with nested git repos (e.g. /mainfolder/.git + /mainfolder/apps/*/.git)
+# setup auto-installs into every nested repo; use --no-recursive to limit to the top-level
+gx setup --target /mainfolder
+gx setup --target /mainfolder --no-recursive
+
 # protected branch management
 gx protect list
 gx protect add release staging
@@ -199,6 +204,7 @@ gx agents stop
 - Setup/doctor can install missing global OMX/OpenSpec/codex-auth with explicit Y/N confirmation.
 - `gx setup` checks GitHub CLI (`gh`) and prints install guidance if missing.
 - Optional parent-folder VS Code Source Control view: `gx setup --target /path/to/repo --parent-workspace-view` creates `../<repo>-branches.code-workspace`.
+- Monorepo-aware: when the target contains nested git repos (e.g. `apps/*/.git`), `gx setup` installs the workflow into every discovered repo. Git submodules (`.git` files) and guardex worktrees under `.omx/agent-worktrees/` are skipped. Opt out with `--no-recursive`; tune discovery with `--max-depth <n>`, `--skip-nested <dir>`, and `--include-submodules`.
 - Interactive self-update prompt defaults to **No** (`[y/N]`).
 - In initialized repos, `setup`/`install`/`fix` block protected-base writes unless explicitly overridden.
 - Direct commits/pushes to protected branches are blocked by default.

--- a/bin/multiagent-safety.js
+++ b/bin/multiagent-safety.js
@@ -425,6 +425,90 @@ function isGitRepo(targetPath) {
   return result.status === 0;
 }
 
+const NESTED_REPO_DEFAULT_MAX_DEPTH = 6;
+const NESTED_REPO_DEFAULT_SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  'build',
+  '.next',
+  '.cache',
+  'target',
+  'vendor',
+  '.venv',
+  '.pnpm-store',
+]);
+const NESTED_REPO_WORKTREE_RELATIVE_DIR = path.join('.omx', 'agent-worktrees');
+
+function discoverNestedGitRepos(rootPath, opts = {}) {
+  const maxDepth = Number.isFinite(opts.maxDepth) ? Math.max(1, opts.maxDepth) : NESTED_REPO_DEFAULT_MAX_DEPTH;
+  const extraSkip = new Set(Array.isArray(opts.extraSkip) ? opts.extraSkip : []);
+  const includeSubmodules = Boolean(opts.includeSubmodules);
+  const resolvedRoot = path.resolve(rootPath);
+
+  const rootCommonDir = (() => {
+    const result = run('git', ['-C', resolvedRoot, 'rev-parse', '--git-common-dir'], { cwd: resolvedRoot });
+    if (result.status !== 0) return null;
+    const raw = result.stdout.trim();
+    if (!raw) return null;
+    return path.resolve(resolvedRoot, raw);
+  })();
+
+  const workreeSkipAbsolute = path.join(resolvedRoot, NESTED_REPO_WORKTREE_RELATIVE_DIR);
+  const found = new Set();
+  found.add(resolvedRoot);
+
+  function shouldSkipDir(dirName) {
+    return NESTED_REPO_DEFAULT_SKIP_DIRS.has(dirName) || extraSkip.has(dirName);
+  }
+
+  function walk(currentPath, depth) {
+    if (depth > maxDepth) return;
+    let entries;
+    try {
+      entries = fs.readdirSync(currentPath, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const entryPath = path.join(currentPath, entry.name);
+
+      if (entry.name === '.git') {
+        if (entry.isDirectory()) {
+          if (entryPath === path.join(resolvedRoot, '.git')) continue;
+          found.add(path.dirname(entryPath));
+        } else if (includeSubmodules && entry.isFile()) {
+          found.add(path.dirname(entryPath));
+        }
+        continue;
+      }
+
+      if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+      if (shouldSkipDir(entry.name)) continue;
+      if (entryPath === workreeSkipAbsolute) continue;
+      walk(entryPath, depth + 1);
+    }
+  }
+
+  walk(resolvedRoot, 0);
+
+  const filtered = Array.from(found).filter((repoPath) => {
+    if (repoPath === resolvedRoot) return true;
+    if (!rootCommonDir) return true;
+    const childResult = run('git', ['-C', repoPath, 'rev-parse', '--git-common-dir'], { cwd: repoPath });
+    if (childResult.status !== 0) return true;
+    const childCommonDirRaw = childResult.stdout.trim();
+    if (!childCommonDirRaw) return true;
+    const childCommonDir = path.resolve(repoPath, childCommonDirRaw);
+    return childCommonDir !== rootCommonDir;
+  });
+
+  const [root, ...rest] = filtered;
+  rest.sort((a, b) => a.localeCompare(b));
+  return [root, ...rest];
+}
+
 function toDestinationPath(relativeTemplatePath) {
   if (relativeTemplatePath.startsWith('scripts/')) {
     return relativeTemplatePath;
@@ -827,16 +911,52 @@ function parseCommonArgs(rawArgs, defaults) {
 }
 
 function parseSetupArgs(rawArgs, defaults) {
-  const setupDefaults = { ...defaults, parentWorkspaceView: false };
+  const setupDefaults = {
+    ...defaults,
+    parentWorkspaceView: false,
+    recursive: true,
+    nestedMaxDepth: NESTED_REPO_DEFAULT_MAX_DEPTH,
+    nestedSkipDirs: [],
+    includeSubmodules: false,
+  };
   const forwardedArgs = [];
 
-  for (const arg of rawArgs) {
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const arg = rawArgs[index];
     if (arg === '--parent-workspace-view') {
       setupDefaults.parentWorkspaceView = true;
       continue;
     }
     if (arg === '--no-parent-workspace-view') {
       setupDefaults.parentWorkspaceView = false;
+      continue;
+    }
+    if (arg === '--no-recursive' || arg === '--no-nested' || arg === '--single-repo') {
+      setupDefaults.recursive = false;
+      continue;
+    }
+    if (arg === '--recursive' || arg === '--nested') {
+      setupDefaults.recursive = true;
+      continue;
+    }
+    if (arg === '--max-depth') {
+      const raw = requireValue(rawArgs, index, '--max-depth');
+      const parsed = Number.parseInt(raw, 10);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        throw new Error('--max-depth requires a positive integer');
+      }
+      setupDefaults.nestedMaxDepth = parsed;
+      index += 1;
+      continue;
+    }
+    if (arg === '--skip-nested') {
+      const raw = requireValue(rawArgs, index, '--skip-nested');
+      setupDefaults.nestedSkipDirs.push(raw);
+      index += 1;
+      continue;
+    }
+    if (arg === '--include-submodules') {
+      setupDefaults.includeSubmodules = true;
       continue;
     }
     forwardedArgs.push(arg);
@@ -4356,24 +4476,87 @@ function setup(rawArgs) {
     }
   }
 
-  assertProtectedMainWriteAllowed(options, 'setup');
-  const installPayload = runInstallInternal(options);
-  installPayload.operations.push(ensureSetupProtectedBranches(installPayload.repoRoot, Boolean(options.dryRun)));
-  if (options.parentWorkspaceView) {
-    installPayload.operations.push(ensureParentWorkspaceView(installPayload.repoRoot, Boolean(options.dryRun)));
-  }
-  printOperations('Setup/install', installPayload, options.dryRun);
+  const topRepoRoot = resolveRepoRoot(options.target);
+  const discoveredRepos = options.recursive
+    ? discoverNestedGitRepos(topRepoRoot, {
+        maxDepth: options.nestedMaxDepth,
+        extraSkip: options.nestedSkipDirs,
+        includeSubmodules: options.includeSubmodules,
+      })
+    : [topRepoRoot];
 
-  const fixPayload = runFixInternal({
-    target: options.target,
-    dryRun: options.dryRun,
-    force: options.force,
-    dropStaleLocks: true,
-    skipAgents: options.skipAgents,
-    skipPackageJson: options.skipPackageJson,
-    skipGitignore: options.skipGitignore,
-  });
-  printOperations('Setup/fix', fixPayload, options.dryRun);
+  if (discoveredRepos.length > 1) {
+    console.log(
+      `[${TOOL_NAME}] Detected ${discoveredRepos.length} git repos under ${topRepoRoot}. Installing into each (use --no-recursive to limit to the top-level).`,
+    );
+    for (const repoPath of discoveredRepos) {
+      const marker = repoPath === topRepoRoot ? ' (top-level)' : '';
+      console.log(`[${TOOL_NAME}]   - ${repoPath}${marker}`);
+    }
+  }
+
+  let aggregateErrors = 0;
+  let aggregateWarnings = 0;
+  let lastScanResult = null;
+
+  for (const repoPath of discoveredRepos) {
+    const perRepoOptions = { ...options, target: repoPath };
+    const repoLabel = discoveredRepos.length > 1 ? ` [${path.relative(topRepoRoot, repoPath) || '.'}]` : '';
+
+    if (discoveredRepos.length > 1) {
+      console.log(`[${TOOL_NAME}] ── Setup target: ${repoPath} ──`);
+    }
+
+    assertProtectedMainWriteAllowed(perRepoOptions, 'setup');
+    const installPayload = runInstallInternal(perRepoOptions);
+    installPayload.operations.push(ensureSetupProtectedBranches(installPayload.repoRoot, Boolean(perRepoOptions.dryRun)));
+    if (perRepoOptions.parentWorkspaceView) {
+      installPayload.operations.push(ensureParentWorkspaceView(installPayload.repoRoot, Boolean(perRepoOptions.dryRun)));
+    }
+    printOperations(`Setup/install${repoLabel}`, installPayload, perRepoOptions.dryRun);
+
+    const fixPayload = runFixInternal({
+      target: repoPath,
+      dryRun: perRepoOptions.dryRun,
+      force: perRepoOptions.force,
+      dropStaleLocks: true,
+      skipAgents: perRepoOptions.skipAgents,
+      skipPackageJson: perRepoOptions.skipPackageJson,
+      skipGitignore: perRepoOptions.skipGitignore,
+    });
+    printOperations(`Setup/fix${repoLabel}`, fixPayload, perRepoOptions.dryRun);
+
+    if (perRepoOptions.dryRun) {
+      continue;
+    }
+
+    if (perRepoOptions.parentWorkspaceView) {
+      const parentWorkspace = buildParentWorkspaceView(installPayload.repoRoot);
+      console.log(`[${TOOL_NAME}] Parent workspace view: ${parentWorkspace.workspacePath}`);
+    }
+
+    const scanResult = runScanInternal({ target: repoPath, json: false });
+    const currentBaseBranch = currentBranchName(scanResult.repoRoot);
+    const autoFinishSummary = autoFinishReadyAgentBranches(scanResult.repoRoot, {
+      baseBranch: currentBaseBranch,
+      dryRun: perRepoOptions.dryRun,
+    });
+    printScanResult(scanResult, false);
+    if (autoFinishSummary.enabled) {
+      console.log(
+        `[${TOOL_NAME}] Auto-finish sweep (base=${currentBaseBranch}): attempted=${autoFinishSummary.attempted}, completed=${autoFinishSummary.completed}, skipped=${autoFinishSummary.skipped}, failed=${autoFinishSummary.failed}`,
+      );
+      for (const detail of autoFinishSummary.details) {
+        console.log(`[${TOOL_NAME}]   ${detail}`);
+      }
+    } else if (autoFinishSummary.details.length > 0) {
+      console.log(`[${TOOL_NAME}] ${autoFinishSummary.details[0]}`);
+    }
+
+    aggregateErrors += scanResult.errors;
+    aggregateWarnings += scanResult.warnings;
+    lastScanResult = scanResult;
+  }
 
   if (options.dryRun) {
     console.log(`[${TOOL_NAME}] Dry run setup done.`);
@@ -4381,31 +4564,10 @@ function setup(rawArgs) {
     return;
   }
 
-  if (options.parentWorkspaceView) {
-    const parentWorkspace = buildParentWorkspaceView(installPayload.repoRoot);
-    console.log(`[${TOOL_NAME}] Parent workspace view: ${parentWorkspace.workspacePath}`);
-  }
-
-  const scanResult = runScanInternal({ target: options.target, json: false });
-  const currentBaseBranch = currentBranchName(scanResult.repoRoot);
-  const autoFinishSummary = autoFinishReadyAgentBranches(scanResult.repoRoot, {
-    baseBranch: currentBaseBranch,
-    dryRun: options.dryRun,
-  });
-  printScanResult(scanResult, false);
-  if (autoFinishSummary.enabled) {
-    console.log(
-      `[${TOOL_NAME}] Auto-finish sweep (base=${currentBaseBranch}): attempted=${autoFinishSummary.attempted}, completed=${autoFinishSummary.completed}, skipped=${autoFinishSummary.skipped}, failed=${autoFinishSummary.failed}`,
-    );
-    for (const detail of autoFinishSummary.details) {
-      console.log(`[${TOOL_NAME}]   ${detail}`);
-    }
-  } else if (autoFinishSummary.details.length > 0) {
-    console.log(`[${TOOL_NAME}] ${autoFinishSummary.details[0]}`);
-  }
-
-  if (scanResult.errors === 0 && scanResult.warnings === 0) {
-    console.log(`[${TOOL_NAME}] ✅ Setup complete.`);
+  if (aggregateErrors === 0 && aggregateWarnings === 0) {
+    const repoCount = discoveredRepos.length;
+    const suffix = repoCount > 1 ? ` (${repoCount} repos)` : '';
+    console.log(`[${TOOL_NAME}] ✅ Setup complete.${suffix}`);
     console.log(`[${TOOL_NAME}] Copy AI setup prompt with: ${SHORT_TOOL_NAME} prompt`);
     console.log(
       `[${TOOL_NAME}] OpenSpec core workflow: /opsx:propose -> /opsx:apply -> /opsx:archive`,
@@ -4416,7 +4578,13 @@ function setup(rawArgs) {
     console.log(`[${TOOL_NAME}] OpenSpec guide: docs/openspec-getting-started.md`);
   }
 
-  setExitCodeFromScan(scanResult);
+  if (lastScanResult) {
+    setExitCodeFromScan({
+      ...lastScanResult,
+      errors: aggregateErrors,
+      warnings: aggregateWarnings,
+    });
+  }
 }
 
 function ensureMainBranch(repoRoot) {

--- a/templates/codex/skills/guardex/SKILL.md
+++ b/templates/codex/skills/guardex/SKILL.md
@@ -20,6 +20,8 @@ gx setup      # install + repair + verify
 gx status     # confirm green
 ```
 
+In a monorepo with nested git repos (top-level `.git` plus `apps/*/.git`), `gx setup` auto-installs into every discovered repo. Submodules and guardex-managed worktrees are skipped. Pass `--no-recursive` to limit to the top-level only.
+
 ## Notes
 
 - Isolation: `scripts/codex-agent.sh "<task>" "<agent>"` is the one-command sandbox start/finish loop.

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -514,6 +514,86 @@ test('init aliases setup and provisions workflow files', () => {
   assert.equal(fs.existsSync(path.join(repoDir, 'AGENTS.md')), true);
 });
 
+test('setup recursively installs into nested git repos, skipping node_modules/worktrees/submodules', () => {
+  const topDir = initRepo();
+
+  const nestedA = path.join(topDir, 'apps', 'a');
+  const nestedB = path.join(topDir, 'apps', 'b');
+  const nodeModulesRepo = path.join(topDir, 'node_modules', 'fake-pkg');
+  const worktreeDir = path.join(topDir, '.omx', 'agent-worktrees', 'child');
+  const submoduleDir = path.join(topDir, 'packages', 'submod');
+
+  for (const dir of [nestedA, nestedB, nodeModulesRepo, worktreeDir, submoduleDir]) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  for (const repo of [nestedA, nestedB, nodeModulesRepo]) {
+    const initResult = runCmd('git', ['init', '-b', 'dev'], repo);
+    assert.equal(initResult.status, 0, initResult.stderr);
+  }
+  fs.writeFileSync(path.join(worktreeDir, '.git'), 'gitdir: ../../../.git/worktrees/child\n', 'utf8');
+  fs.writeFileSync(path.join(submoduleDir, '.git'), 'gitdir: ../../.git/modules/submod\n', 'utf8');
+
+  const result = runNode(['setup', '--target', topDir, '--no-global-install'], topDir);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /Detected 3 git repos under/);
+  assert.match(result.stdout, /Setup complete\. \(3 repos\)/);
+
+  for (const repo of [topDir, nestedA, nestedB]) {
+    assert.equal(fs.existsSync(path.join(repo, 'AGENTS.md')), true, `AGENTS.md missing in ${repo}`);
+    assert.equal(
+      fs.existsSync(path.join(repo, 'scripts', 'agent-branch-start.sh')),
+      true,
+      `agent-branch-start.sh missing in ${repo}`,
+    );
+    assert.equal(
+      fs.existsSync(path.join(repo, '.githooks', 'pre-commit')),
+      true,
+      `pre-commit hook missing in ${repo}`,
+    );
+    assert.equal(
+      fs.existsSync(path.join(repo, '.omx', 'state', 'agent-file-locks.json')),
+      true,
+      `lock registry missing in ${repo}`,
+    );
+  }
+
+  for (const decoy of [nodeModulesRepo, worktreeDir, submoduleDir]) {
+    assert.equal(
+      fs.existsSync(path.join(decoy, 'AGENTS.md')),
+      false,
+      `AGENTS.md should not be installed in ${decoy}`,
+    );
+    assert.equal(
+      fs.existsSync(path.join(decoy, 'scripts', 'agent-branch-start.sh')),
+      false,
+      `scripts should not be installed in ${decoy}`,
+    );
+  }
+});
+
+test('setup --no-recursive limits install to the top-level repo', () => {
+  const topDir = initRepo();
+  const nestedA = path.join(topDir, 'apps', 'a');
+  fs.mkdirSync(nestedA, { recursive: true });
+  const initResult = runCmd('git', ['init', '-b', 'dev'], nestedA);
+  assert.equal(initResult.status, 0, initResult.stderr);
+
+  const result = runNode(
+    ['setup', '--target', topDir, '--no-global-install', '--no-recursive'],
+    topDir,
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.doesNotMatch(result.stdout, /Detected \d+ git repos under/);
+
+  assert.equal(fs.existsSync(path.join(topDir, 'AGENTS.md')), true);
+  assert.equal(
+    fs.existsSync(path.join(nestedA, 'AGENTS.md')),
+    false,
+    'nested repo must not be touched when --no-recursive is set',
+  );
+});
+
 test('review-bot-watch script prints help after setup', () => {
   const repoDir = initRepo();
 


### PR DESCRIPTION
## Summary

- `gx setup` now detects nested git repos (e.g. `apps/*/.git` inside a monorepo) and installs the guardex workflow into every discovered repo with a single command.
- New flags: `--no-recursive`, `--max-depth <n>`, `--skip-nested <dir>` (repeatable), `--include-submodules`.
- Skip list by default: `node_modules/`, `.git/`, guardex sandbox worktrees under `.omx/agent-worktrees/`, and `.git`-file submodules.

## Test plan

- [x] New regression test: `setup recursively installs into nested git repos, skipping node_modules/worktrees/submodules`
- [x] New regression test: `setup --no-recursive limits install to the top-level repo`
- [x] `npm test` — full suite against feature branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)