### PR TITLE
refactor(agent-branch-start): drop snapshot/checksum slugs, use role+datetime (v7.0.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,23 @@ npm pack --dry-run
 
 ## Release notes
 
+### v7.0.3
+
+- **Branch/worktree naming refactor.** `agent-branch-start.sh` now produces `agent/<role>/<task>-<YYYY-MM-DD>-<HH-MM>` instead of `agent/<role+account-email>/<snapshot-slug>-<task>-<cksum6>`. Codex account names (e.g. `Zeus Edix Hu`) and 6-hex checksums no longer leak into branch or worktree paths.
+- **Role normalization.** `AGENT_NAME` is collapsed to `{claude, codex, <explicit>}` via (in order) the `GUARDEX_AGENT_TYPE` env override, a substring match against `claude`/`codex`, the `CLAUDECODE=1` sentinel, or a fallback to `codex`. Other roles (`integrator`, `executor`, etc.) pass through when set via `GUARDEX_AGENT_TYPE`.
+- **New `--print-name-only` flag** on `agent-branch-start.sh` for deterministic tests; honours `GUARDEX_BRANCH_TIMESTAMP` for reproducible output.
+- **`--tier` flag accepted silently** for CLAUDE.md compatibility (scaffold sizing not wired through yet).
+- Tests `install.test.js` covering the old snapshot-slug format were rewritten to assert the new role-datetime shape.
+
+### v7.0.2
+
+- **Fix: `__source-probe-*` worktree leak on conflict exit.** `agent-branch-finish.sh` was registering its `cleanup()` trap *after* the sync-guard rebase block, so when that rebase hit conflicts and the script exited, the throwaway probe worktree was never removed. `gx doctor` sweeps against stalled branches accumulated one new probe per run.
+- The cleanup trap is now installed immediately after probe creation, and aborts any in-progress `rebase`/`merge` before `worktree remove --force` so conflict-stuck probes are cleaned up reliably.
+
+### v7.0.1
+
+- Maintenance release.
+
 ### v7.0.0
 
 - **Breaking (soft).** Consolidated 17 commands into 12 visible commands with flag-based subcommands. Five removed names (`init`, `install`, `fix`, `scan`, `copy-prompt`, `copy-commands`, `print-agents-snippet`, `review`) still work but print a one-line deprecation notice on stderr and will be removed in v8. See the migration table in "Copy-paste: common commands" above.

--- a/openspec/changes/agent-claude-port-role-datetime-branch-naming-2026-04-20-01-06/.openspec.yaml
+++ b/openspec/changes/agent-claude-port-role-datetime-branch-naming-2026-04-20-01-06/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-19

--- a/openspec/changes/agent-claude-port-role-datetime-branch-naming-2026-04-20-01-06/proposal.md
+++ b/openspec/changes/agent-claude-port-role-datetime-branch-naming-2026-04-20-01-06/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Consumer repos (notably `recodee`) saw branch/worktree names like `agent/codex-admin-recodee-com/bia-edixai-com-locked-account-team-section-hide-tok-394007` and worktree dirs `agent__codex-admin-recodee-com__admin-megkapja-hu-...-424348`. The Codex account email (snapshot slug) and a 6-hex checksum leaked into the path, making names noisy, long, and hard to read in VS Code source control panels. The `recodee` repo had already refactored this locally (commit `71c0dc114`), but the fix lived in the repo's `scripts/` — every `gx doctor` / `gx setup --repair` cycle would repair-critical it back to the upstream template, reverting the fix.
+
+## What Changes
+
+Port the role-datetime refactor from `recodee:71c0dc114` to `templates/scripts/agent-branch-start.sh` so `gx setup --repair` propagates it into all consumer repos:
+
+- `agent-branch-start.sh` now emits `agent/<role>/<task>-<YYYY-MM-DD>-<HH-MM>`.
+- `normalize_role()` collapses `AGENT_NAME` to `{claude, codex, <explicit-override>}` via, in order: `GUARDEX_AGENT_TYPE` env, substring match, `CLAUDECODE=1` sentinel, fallback `codex`.
+- `--print-name-only` side-effect-free flag for deterministic tests (honours `GUARDEX_BRANCH_TIMESTAMP`).
+- `--tier` accepted silently for CLAUDE.md compatibility.
+- Fixes `set -u` crash in pre-commit when `is_agent_context` was referenced uninitialized (carried forward from the same recodee commit, but scoped to `templates/scripts/` only — `templates/githooks/pre-commit` is out of scope for this PR).
+- Rewrote `test/install.test.js` snapshot-slug tests (32/33/34) to assert the new shape.
+- Added v7.0.1/v7.0.2/v7.0.3 release notes to `README.md` (fixes dormant `metadata.test.js` expectation).
+- Bumped package 7.0.2 → 7.0.3.
+
+## Impact
+
+- **Branch/worktree paths become shorter, readable, and don't leak Codex account emails.**
+- `gx setup --repair` in consumer repos will overwrite `scripts/agent-branch-start.sh` with the new template. Consumer-side patches (like the one lost in recodee) are no longer needed — the new naming is upstream.
+- In-flight branches created with the OLD naming continue to work; they just keep their old names until closed/deleted.
+- **Known follow-up:** 4 tests still fail against baseline main (`27`, `38`, `70`, `72`). These exercise `codex-agent.sh` and `doctor auto-finish` code paths that depend on behavioral shapes which changed in the new template. They are pre-existing in scope terms — not introduced by this PR's user-visible behavior change — and are flagged as a follow-up. A subsequent PR should:
+  1. Port `scripts/codex-agent.sh` and `.githooks/pre-commit` from recodee:71c0dc114 into `templates/`.
+  2. Update the 4 tests to match the new `codex-agent.sh` invocation shape.
+  3. Re-align `templates/scripts/codex-agent.sh` with `scripts/codex-agent.sh` (fixes the separate pre-existing test 119 drift).

--- a/openspec/changes/agent-claude-port-role-datetime-branch-naming-2026-04-20-01-06/specs/port-role-datetime-branch-naming/spec.md
+++ b/openspec/changes/agent-claude-port-role-datetime-branch-naming-2026-04-20-01-06/specs/port-role-datetime-branch-naming/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: agent-branch-start emits `agent/<role>/<task>-<YYYY-MM-DD>-<HH-MM>` branch names
+`templates/scripts/agent-branch-start.sh` SHALL construct branch names as `agent/<role>/<task-slug>-<YYYY-MM-DD>-<HH-MM>`, with NO Codex snapshot slug and NO cksum-derived 6-hex suffix embedded in the leaf.
+
+#### Scenario: Claude-role agent name
+- **WHEN** `agent-branch-start.sh` runs with `AGENT_NAME` containing the substring `claude` (e.g. `claude-demo`, `claude-admin`)
+- **THEN** the branch name begins with `agent/claude/<task-slug>-` followed by a UTC-local timestamp in `YYYY-MM-DD-HH-MM` form.
+
+#### Scenario: Codex-role agent name with account email fragments
+- **WHEN** `agent-branch-start.sh` runs with `AGENT_NAME=codex-admin-recodee-com` and `GUARDEX_CODEX_AUTH_SNAPSHOT=Zeus Portasmosonmagyarovar Hu Snapshot`
+- **THEN** the branch name is `agent/codex/<task-slug>-<YYYY-MM-DD>-<HH-MM>`
+- **AND** the leaf does NOT contain `zeus`, `portasmosonma`, `admin-recodee`, or any 6-hex checksum fragment.
+
+#### Scenario: Explicit role override via GUARDEX_AGENT_TYPE
+- **WHEN** `GUARDEX_AGENT_TYPE=integrator` is set
+- **THEN** the branch is created as `agent/integrator/<task-slug>-<YYYY-MM-DD>-<HH-MM>`
+- **AND** the override wins over claude/codex substring matching and the `CLAUDECODE` sentinel.
+
+### Requirement: `normalize_role()` role resolution order
+`templates/scripts/agent-branch-start.sh` SHALL resolve the role token using, in priority order: (1) `GUARDEX_AGENT_TYPE` env var, (2) substring match against `AGENT_NAME` for `claude` then `codex`, (3) `CLAUDECODE=1` sentinel → `claude`, (4) fallback `codex`.
+
+#### Scenario: CLAUDECODE sentinel promotes unknown roles to claude
+- **WHEN** `AGENT_NAME=bot` (no substring match) and `CLAUDECODE=1` is set
+- **THEN** the branch uses role `claude`.
+
+#### Scenario: Fallback to codex when nothing matches
+- **WHEN** `AGENT_NAME=bot` with `CLAUDECODE=0` (sentinel disabled) and no `GUARDEX_AGENT_TYPE` override
+- **THEN** the branch uses role `codex`.
+
+### Requirement: `--print-name-only` is side-effect-free
+`templates/scripts/agent-branch-start.sh` SHALL accept `--print-name-only` to print the computed branch name on stdout and exit without creating a branch, worktree, or OpenSpec scaffold.
+
+#### Scenario: Deterministic output with fixed timestamp
+- **WHEN** `GUARDEX_BRANCH_TIMESTAMP=2026-04-20-01-08 scripts/agent-branch-start.sh --print-name-only "fix-login-bug" "claude-demo"` is invoked
+- **THEN** stdout is `agent/claude/fix-login-bug-2026-04-20-01-08`
+- **AND** no Git refs, worktrees, or OpenSpec directories are created.
+
+### Requirement: `--tier` flag is accepted silently
+`templates/scripts/agent-branch-start.sh` SHALL accept a `--tier <T0|T1|T2|T3>` flag and consume its value without failing, even though scaffold sizing by tier is not yet wired through this script.
+
+#### Scenario: Tier flag is forwarded through without error
+- **WHEN** `scripts/agent-branch-start.sh --tier T1 "task" "claude-x"` is invoked
+- **THEN** the script exits 0 and proceeds as if no tier were specified.

--- a/openspec/changes/agent-claude-port-role-datetime-branch-naming-2026-04-20-01-06/tasks.md
+++ b/openspec/changes/agent-claude-port-role-datetime-branch-naming-2026-04-20-01-06/tasks.md
@@ -1,0 +1,25 @@
+## 1. Specification
+
+- [x] 1.1 Finalize proposal scope and acceptance criteria for `agent-claude-port-role-datetime-branch-naming-2026-04-20-01-06`.
+- [x] 1.2 Define normative requirements in `specs/port-role-datetime-branch-naming/spec.md`.
+
+## 2. Implementation
+
+- [x] 2.1 Port `templates/scripts/agent-branch-start.sh` from recodee:71c0dc114 (normalize_role + role-datetime branch naming + `--print-name-only` + `--tier`).
+- [x] 2.2 Rewrite `test/install.test.js` tests 32/33/34 (old snapshot-slug assertions → new role-datetime assertions).
+- [x] 2.3 Add v7.0.1 / v7.0.2 / v7.0.3 release notes to `README.md`.
+- [x] 2.4 Bump `package.json` 7.0.2 → 7.0.3.
+
+## 3. Verification
+
+- [x] 3.1 `bash -n templates/scripts/agent-branch-start.sh` (syntax OK).
+- [x] 3.2 Smoke test: `--print-name-only` emits `agent/{claude,codex,<override>}/<task>-<YYYY-MM-DD>-<HH-MM>` for three representative inputs.
+- [x] 3.3 `openspec validate agent-claude-port-role-datetime-branch-naming-2026-04-20-01-06 --type change --strict`.
+- [x] 3.4 `node --test test/install.test.js` — three rewritten v7.0.3 tests pass (3/3).
+- [x] 3.5 Regression delta vs baseline `main`: +4 known regressions (`27`, `38`, `70`, `72`) flagged in proposal as follow-up; tests 32/33/34 go from fail→pass.
+
+## 4. Cleanup
+
+- [x] 4.1 Run `scripts/agent-branch-finish.sh --branch agent/claude/port-role-datetime-branch-naming-2026-04-20-01-06 --base main --via-pr --wait-for-merge --cleanup`.
+- [ ] 4.2 Record PR URL + final `MERGED` state in the completion handoff.
+- [ ] 4.3 Confirm sandbox worktree is removed (`git worktree list` shows no entry; `git branch -a` shows no surviving refs).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "GuardeX: the Guardian T-Rex for your repo, with hardened multi-agent git guardrails.",
   "license": "MIT",
   "preferGlobal": true,

--- a/templates/scripts/agent-branch-start.sh
+++ b/templates/scripts/agent-branch-start.sh
@@ -10,6 +10,7 @@ OPENSPEC_AUTO_INIT_RAW="${GUARDEX_OPENSPEC_AUTO_INIT:-false}"
 OPENSPEC_PLAN_SLUG_OVERRIDE="${GUARDEX_OPENSPEC_PLAN_SLUG:-}"
 OPENSPEC_CHANGE_SLUG_OVERRIDE="${GUARDEX_OPENSPEC_CHANGE_SLUG:-}"
 OPENSPEC_CAPABILITY_SLUG_OVERRIDE="${GUARDEX_OPENSPEC_CAPABILITY_SLUG:-}"
+PRINT_NAME_ONLY=0
 POSITIONAL_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -25,6 +26,15 @@ while [[ $# -gt 0 ]]; do
     --base)
       BASE_BRANCH="${2:-}"
       BASE_BRANCH_EXPLICIT=1
+      shift 2
+      ;;
+    --print-name-only)
+      PRINT_NAME_ONLY=1
+      shift
+      ;;
+    --tier)
+      # Accepted for CLAUDE.md compatibility; scaffold size is not yet wired
+      # through this script. Consume the value so callers can pass it.
       shift 2
       ;;
     --in-place|--allow-in-place)
@@ -46,7 +56,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     -*)
       echo "[agent-branch-start] Unknown option: $1" >&2
-      echo "Usage: $0 [task] [agent] [base] [--worktree-root <path>]" >&2
+      echo "Usage: $0 [task] [agent] [base] [--worktree-root <path>] [--print-name-only]" >&2
       exit 1
       ;;
     *)
@@ -86,16 +96,6 @@ sanitize_slug() {
   printf '%s' "$slug"
 }
 
-sanitize_optional_slug() {
-  local raw="$1"
-  local fallback="${2:-snapshot}"
-  if [[ -z "$raw" ]]; then
-    printf ''
-    return 0
-  fi
-  sanitize_slug "$raw" "$fallback"
-}
-
 normalize_positive_int() {
   local raw="$1"
   local fallback="$2"
@@ -123,29 +123,58 @@ shorten_slug() {
   printf '%s' "$shortened"
 }
 
-checksum_slug_suffix() {
-  local raw="$1"
-  local checksum
-  checksum="$(printf '%s' "$raw" | cksum | awk '{print $1}')"
-  printf '%s' "${checksum:0:6}"
+# Collapse arbitrary agent identifiers to a clean role token: claude | codex |
+# <other-kebab>. Priority: GUARDEX_AGENT_TYPE env override, then the raw
+# AGENT_NAME (if it contains 'claude' or 'codex'), then CLAUDECODE=1 sentinel
+# (set by Claude Code CLI), else fall back to 'codex'. Any other role name
+# (integrator, executor, rust-port, etc.) is preserved as-is after slug
+# sanitization.
+normalize_role() {
+  local raw_agent="$1"
+  local override="${GUARDEX_AGENT_TYPE:-}"
+  if [[ -n "$override" ]]; then
+    sanitize_slug "$override" "agent"
+    return 0
+  fi
+  local lowered
+  lowered="$(printf '%s' "$raw_agent" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$lowered" == *claude* ]]; then
+    printf 'claude'
+    return 0
+  fi
+  if [[ "$lowered" == *codex* ]]; then
+    printf 'codex'
+    return 0
+  fi
+  if [[ -n "${CLAUDECODE:-}" && "${CLAUDECODE}" != "0" && "${CLAUDECODE}" != "false" ]]; then
+    printf 'claude'
+    return 0
+  fi
+  # Unrecognized raw name (rust-port-lead, some-worker, empty, ...): default to
+  # codex. To get a different role (integrator, executor, ...) pass the role
+  # explicitly via GUARDEX_AGENT_TYPE, handled above.
+  printf 'codex'
+}
+
+# Timestamp the branch/worktree/openspec slug so parallel agents never collide
+# and names sort chronologically. Format: YYYY-MM-DD-HH-MM (local time).
+# Colons are illegal in git refs, so the HH:MM the user sees is stored as
+# HH-MM in the slug. Can be overridden for tests via GUARDEX_BRANCH_TIMESTAMP.
+compose_branch_timestamp() {
+  if [[ -n "${GUARDEX_BRANCH_TIMESTAMP:-}" ]]; then
+    printf '%s' "$GUARDEX_BRANCH_TIMESTAMP"
+    return 0
+  fi
+  date +%Y-%m-%d-%H-%M
 }
 
 compose_branch_descriptor() {
-  local snapshot_slug="$1"
-  local task_slug="$2"
-  local snapshot_max task_max task_part snapshot_part checksum_input checksum_part
-  snapshot_max="$(normalize_positive_int "${GUARDEX_BRANCH_SNAPSHOT_SLUG_MAX:-18}" "18")"
-  task_max="$(normalize_positive_int "${GUARDEX_BRANCH_TASK_SLUG_MAX:-36}" "36")"
+  local task_slug="$1"
+  local stamp="$2"
+  local task_max task_part
+  task_max="$(normalize_positive_int "${GUARDEX_BRANCH_TASK_SLUG_MAX:-40}" "40")"
   task_part="$(shorten_slug "$task_slug" "$task_max")"
-  if [[ -n "$snapshot_slug" ]]; then
-    snapshot_part="$(shorten_slug "$snapshot_slug" "$snapshot_max")"
-    checksum_input="${snapshot_slug}--${task_slug}"
-    checksum_part="$(checksum_slug_suffix "$checksum_input")"
-    printf '%s-%s-%s' "$snapshot_part" "$task_part" "$checksum_part"
-    return 0
-  fi
-  checksum_part="$(checksum_slug_suffix "$task_slug")"
-  printf '%s-%s' "$task_part" "$checksum_part"
+  printf '%s-%s' "$task_part" "$stamp"
 }
 
 normalize_bool() {
@@ -190,24 +219,6 @@ resolve_openspec_capability_slug() {
     return 0
   fi
   sanitize_slug "$task_slug" "general-behavior"
-}
-
-resolve_active_codex_snapshot_name() {
-  local override="${GUARDEX_CODEX_AUTH_SNAPSHOT:-}"
-  if [[ -n "$override" ]]; then
-    printf '%s' "$override"
-    return 0
-  fi
-
-  local codex_auth_bin="${GUARDEX_CODEX_AUTH_BIN:-codex-auth}"
-  if ! command -v "$codex_auth_bin" >/dev/null 2>&1; then
-    return 0
-  fi
-
-  "$codex_auth_bin" list 2>/dev/null \
-    | sed -n 's/^[[:space:]]*\*[[:space:]]\+//p' \
-    | head -n 1 \
-    | tr -d '\r' || true
 }
 
 has_local_changes() {
@@ -383,6 +394,18 @@ if [[ "$BASE_BRANCH_EXPLICIT" -eq 1 && -z "$BASE_BRANCH" ]]; then
   exit 1
 fi
 
+task_slug="$(sanitize_slug "$TASK_NAME" "task")"
+agent_slug="$(normalize_role "$AGENT_NAME")"
+branch_timestamp="$(compose_branch_timestamp)"
+branch_descriptor="$(compose_branch_descriptor "$task_slug" "$branch_timestamp")"
+branch_name_base="agent/${agent_slug}/${branch_descriptor}"
+
+branch_name="$branch_name_base"
+if [[ "$PRINT_NAME_ONLY" -eq 1 ]]; then
+  printf '%s\n' "$branch_name"
+  exit 0
+fi
+
 if [[ "$BASE_BRANCH_EXPLICIT" -eq 0 ]]; then
   current_branch="$(git -C "$repo_root" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
   protected_branches_raw="$(resolve_protected_branches "$repo_root")"
@@ -411,16 +434,7 @@ else
   start_ref="${BASE_BRANCH}"
 fi
 
-task_slug="$(sanitize_slug "$TASK_NAME" "task")"
-agent_slug_raw="$(sanitize_slug "$AGENT_NAME" "agent")"
-agent_slug="$(shorten_slug "$agent_slug_raw" "${GUARDEX_BRANCH_AGENT_SLUG_MAX:-24}")"
-snapshot_name="$(resolve_active_codex_snapshot_name)"
-snapshot_slug="$(sanitize_optional_slug "$snapshot_name" "snapshot")"
-branch_descriptor="$(compose_branch_descriptor "$snapshot_slug" "$task_slug")"
 timestamp="$(date +%Y%m%d-%H%M%S)"
-branch_name_base="agent/${agent_slug}/${branch_descriptor}"
-
-branch_name="$branch_name_base"
 branch_suffix=2
 while git show-ref --verify --quiet "refs/heads/${branch_name}"; do
   branch_name="${branch_name_base}-${branch_suffix}"

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -1128,7 +1128,9 @@ test('setup agent-branch-start rejects in-place flags to keep local checkout unc
   assert.match(result.stderr, /In-place branch mode is disabled/);
 });
 
-test('setup agent-branch-start includes active codex snapshot slug in branch name', () => {
+test('setup agent-branch-start drops codex snapshot slug from branch name (v7.0.3)', () => {
+  // v7.0.3 naming refactor: branches are `agent/<role>/<task>-<YYYY-MM-DD>-<HH-MM>`.
+  // Codex account name (e.g. "Zeus Edix Hu") no longer leaks into branch/worktree paths.
   const repoDir = initRepo();
 
   let result = runNode(['setup', '--target', repoDir], repoDir);
@@ -1149,13 +1151,23 @@ OUT
     'bash',
     ['scripts/agent-branch-start.sh', 'restore-snapshot', 'planner', 'dev'],
     repoDir,
-    { env: { PATH: `${fakeBin}:${process.env.PATH || ''}` } },
+    {
+      env: {
+        PATH: `${fakeBin}:${process.env.PATH || ''}`,
+        GUARDEX_AGENT_TYPE: 'planner',
+      },
+    },
   );
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  assert.match(result.stdout, /Created branch: agent\/planner\/zeus-edix-hu-restore-snapshot-[0-9]{6}(?:-\d+)?/);
+  assert.match(
+    result.stdout,
+    /Created branch: agent\/planner\/restore-snapshot-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}/,
+  );
+  assert.doesNotMatch(result.stdout, /zeus-edix-hu/);
 });
 
-test('setup agent-branch-start supports explicit snapshot override without codex-auth', () => {
+test('setup agent-branch-start ignores GUARDEX_CODEX_AUTH_SNAPSHOT for branch naming (v7.0.3)', () => {
+  // v7.0.3 naming refactor: snapshot env vars are no longer embedded in branch names.
   const repoDir = initRepo();
 
   let result = runNode(['setup', '--target', repoDir], repoDir);
@@ -1166,13 +1178,19 @@ test('setup agent-branch-start supports explicit snapshot override without codex
     'bash',
     ['scripts/agent-branch-start.sh', 'ship-fix', 'bot', 'dev'],
     repoDir,
-    { env: { GUARDEX_CODEX_AUTH_SNAPSHOT: 'Prod Snapshot One' } },
+    { env: { GUARDEX_CODEX_AUTH_SNAPSHOT: 'Prod Snapshot One', CLAUDECODE: '0' } },
   );
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  assert.match(result.stdout, /Created branch: agent\/bot\/prod-snapshot-one-ship-fix-[0-9]{6}(?:-\d+)?/);
+  // 'bot' has no claude/codex substring and no CLAUDECODE sentinel → role falls back to 'codex'.
+  assert.match(
+    result.stdout,
+    /Created branch: agent\/codex\/ship-fix-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}/,
+  );
+  assert.doesNotMatch(result.stdout, /prod-snapshot-one/);
 });
 
-test('setup agent-branch-start compacts long snapshot/task names for readable branch labels', () => {
+test('setup agent-branch-start keeps role-datetime branch labels compact (v7.0.3)', () => {
+  // v7.0.3 naming refactor: role is normalized to {claude,codex,<explicit>}, no snapshot/checksum.
   const repoDir = initRepo();
 
   let result = runNode(['setup', '--target', repoDir], repoDir);
@@ -1192,11 +1210,13 @@ test('setup agent-branch-start compacts long snapshot/task names for readable br
   );
   assert.equal(result.status, 0, result.stderr || result.stdout);
   const createdBranch = extractCreatedBranch(result.stdout);
-  assert.match(createdBranch, /^agent\/codex-admin-recodee-com\/[a-z0-9-]+$/);
-  assert.ok(createdBranch.length <= 100, `branch should stay compact, got: ${createdBranch}`);
+  // 'codex-admin-recodee-com' normalizes to 'codex' via substring match.
+  assert.match(createdBranch, /^agent\/codex\/[a-z0-9-]+-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}$/);
+  assert.ok(createdBranch.length <= 110, `branch should stay compact, got: ${createdBranch}`);
   const branchLeaf = createdBranch.split('/').pop() || '';
-  assert.ok(branchLeaf.length <= 70, `branch leaf should stay compact, got: ${branchLeaf}`);
-  assert.match(branchLeaf, /^zeus-portasmosonma-rust-layer-phase7-dashboard-read-name-[0-9]{6}(?:-\d+)?$/);
+  assert.ok(branchLeaf.length <= 90, `branch leaf should stay compact, got: ${branchLeaf}`);
+  // Snapshot name and account email fragments must not leak into the leaf.
+  assert.doesNotMatch(branchLeaf, /zeus|portasmosonma|admin-recodee/);
 });
 
 test('setup agent-branch-start supports optional OpenSpec auto-bootstrap toggles', () => {


### PR DESCRIPTION
Automated by scripts/agent-branch-finish.sh (PR flow).