### PR TITLE
Plan mode: use agent/plan branches and persist .omx plan drafts

### DIFF
--- a/openspec/changes/agent-codex-plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/.openspec.yaml
+++ b/openspec/changes/agent-codex-plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-20

--- a/openspec/changes/agent-codex-plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/proposal.md
+++ b/openspec/changes/agent-codex-plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+- `ralplan` and Claude plan-mode workflows were not guaranteed to start from a
+  dedicated planning branch role, so planning sessions looked like generic
+  execution branches.
+- Plan-mode sessions also lacked a guaranteed persisted markdown artifact under
+  `.omx/plans/`, making phase handoff/re-entry inconsistent.
+
+## What Changes
+
+- Add plan-mode detection to `scripts/agent-branch-start.sh` and
+  `templates/scripts/agent-branch-start.sh` using:
+  - explicit flags (`--plan-mode` / `--no-plan-mode`)
+  - permission-mode signals (`*PERMISSION_MODE=plan`)
+  - ralplan workflow hints (`*WORKFLOW_KEYWORD` / `*ACTIVE_SKILL`)
+  - recent active `.omx/state/sessions/*/ralplan-state.json`
+- Force plan-mode starts onto `agent/plan/<task>-<timestamp>` while preserving
+  `agent/*` guardrail compatibility.
+- Generate `.omx/plans/<YYYY-MM-DD>-<task>.md` for plan-mode starts with a PRD
+  structure and phased backlog template.
+- Teach `scripts/codex-agent.sh` and `templates/scripts/codex-agent.sh` to pass
+  `--plan-mode` to branch-start when Codex/Claude args include
+  `--permission-mode plan` or plan-mode env toggles.
+- Add regression tests in `test/install.test.js` for:
+  - explicit plan-mode branch + markdown artifact creation
+  - Claude plan-permission env auto-detection
+  - codex-agent forwarding of `--permission-mode plan`
+
+## Impact
+
+- Affected surfaces:
+  - `scripts/agent-branch-start.sh`
+  - `templates/scripts/agent-branch-start.sh`
+  - `scripts/codex-agent.sh`
+  - `templates/scripts/codex-agent.sh`
+  - `test/install.test.js`
+- Risk: false-positive plan-mode activation from stale ralplan state files.
+  Mitigation: only treat recent (<=6h) active ralplan state as a signal.
+- Branch naming remains under `agent/*`, so pre-commit, finish, and prune
+  guardrails continue to work without contract changes.

--- a/openspec/changes/agent-codex-plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/specs/plan-mode-agent-plan-branch-and-md/spec.md
+++ b/openspec/changes/agent-codex-plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/specs/plan-mode-agent-plan-branch-and-md/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: plan-mode-agent-plan-branch-and-md behavior
+The system SHALL normalize plan-mode branch starts to a dedicated planning role
+and persist a reusable phased plan markdown artifact under `.omx/plans/`.
+
+#### Scenario: explicit plan-mode flag creates `agent/plan/*` branch
+- **WHEN** `scripts/agent-branch-start.sh` is called with `--plan-mode`
+- **THEN** the created branch SHALL match `agent/plan/<task>-<YYYY-MM-DD-HH-MM>`
+- **AND** OpenSpec change/plan slugs SHALL derive from that branch name.
+
+#### Scenario: permission-mode signals auto-enable plan mode
+- **WHEN** plan permissions are signaled via environment
+  (`CLAUDE_PERMISSION_MODE=plan`, `CODEX_PERMISSION_MODE=plan`, etc.)
+- **THEN** `scripts/agent-branch-start.sh` SHALL create an `agent/plan/*` branch
+  without requiring `--plan-mode`.
+
+#### Scenario: plan-mode start persists a PRD markdown draft
+- **WHEN** a plan-mode sandbox starts
+- **THEN** the worktree SHALL contain `.omx/plans/<YYYY-MM-DD>-<task>.md`
+- **AND** that markdown SHALL include a PRD layout with numbered sections and a
+  phased backlog (Phase 1..4 template).
+
+### Requirement: codex-agent plan-mode forwarding
+`scripts/codex-agent.sh` and template variants SHALL forward plan-mode intent to
+branch-start.
+
+#### Scenario: `--permission-mode plan` is passed through codex-agent
+- **WHEN** `scripts/codex-agent.sh ... --permission-mode plan` is run
+- **THEN** the starter invocation SHALL include `--plan-mode`
+- **AND** the resulting sandbox branch SHALL be `agent/plan/*`.

--- a/openspec/changes/agent-codex-plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/tasks.md
+++ b/openspec/changes/agent-codex-plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/tasks.md
@@ -1,0 +1,15 @@
+## 1. Specification
+
+- [x] 1.1 Finalize proposal scope and acceptance criteria for `agent-codex-plan-mode-agent-plan-branch-and-md-2026-04-20-08-57`.
+- [x] 1.2 Define normative requirements in `specs/plan-mode-agent-plan-branch-and-md/spec.md`.
+
+## 2. Implementation
+
+- [x] 2.1 Implement scoped behavior changes.
+- [x] 2.2 Add/update focused regression coverage.
+
+## 3. Verification
+
+- [x] 3.1 Run targeted project verification commands.
+- [x] 3.2 Run `openspec validate agent-codex-plan-mode-agent-plan-branch-and-md-2026-04-20-08-57 --type change --strict`.
+- [x] 3.3 Run `openspec validate --specs`.

--- a/scripts/agent-branch-start.sh
+++ b/scripts/agent-branch-start.sh
@@ -13,6 +13,8 @@ OPENSPEC_CHANGE_SLUG_OVERRIDE="${GUARDEX_OPENSPEC_CHANGE_SLUG:-}"
 OPENSPEC_CAPABILITY_SLUG_OVERRIDE="${GUARDEX_OPENSPEC_CAPABILITY_SLUG:-}"
 PR_REF="${GUARDEX_GH_PR_REF:-}"
 GH_REPO_REF="${GUARDEX_GH_REPO:-}"
+PLAN_MODE_RAW="${GX_PLAN_MODE:-${GUARDEX_PLAN_MODE:-}}"
+PLAN_MODE_EXPLICIT=0
 PRINT_NAME_ONLY=0
 POSITIONAL_ARGS=()
 
@@ -60,6 +62,16 @@ while [[ $# -gt 0 ]]; do
       PRINT_NAME_ONLY=1
       shift
       ;;
+    --plan-mode)
+      PLAN_MODE_RAW="true"
+      PLAN_MODE_EXPLICIT=1
+      shift
+      ;;
+    --no-plan-mode)
+      PLAN_MODE_RAW="false"
+      PLAN_MODE_EXPLICIT=1
+      shift
+      ;;
     --tier)
       # Accepted for CLAUDE.md compatibility; scaffold size is not yet wired
       # through this script. Consume the value so callers can pass it.
@@ -75,7 +87,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     -*)
       echo "[agent-branch-start] Unknown option: $1" >&2
-      echo "Usage: $0 [task] [agent] [base] [--worktree-root <path>] [--pr <ref>] [--repo <owner/name>] [--gh-sync|--no-gh-sync] [--print-name-only]" >&2
+      echo "Usage: $0 [task] [agent] [base] [--worktree-root <path>] [--pr <ref>] [--repo <owner/name>] [--gh-sync|--no-gh-sync] [--plan-mode|--no-plan-mode] [--print-name-only]" >&2
       exit 1
       ;;
     *)
@@ -87,7 +99,7 @@ done
 
 if [[ "${#POSITIONAL_ARGS[@]}" -gt 3 ]]; then
   echo "[agent-branch-start] Too many positional arguments." >&2
-  echo "Usage: $0 [task] [agent] [base] [--worktree-root <path>] [--pr <ref>] [--repo <owner/name>] [--gh-sync|--no-gh-sync]" >&2
+  echo "Usage: $0 [task] [agent] [base] [--worktree-root <path>] [--pr <ref>] [--repo <owner/name>] [--gh-sync|--no-gh-sync] [--plan-mode|--no-plan-mode]" >&2
   exit 1
 fi
 
@@ -203,6 +215,72 @@ normalize_bool() {
     '') printf '%s' "$fallback" ;;
     *) printf '%s' "$fallback" ;;
   esac
+}
+
+is_plan_permission_mode() {
+  local raw lowered
+  for raw in \
+    "${GUARDEX_PERMISSION_MODE:-}" \
+    "${OMX_PERMISSION_MODE:-}" \
+    "${CODEX_PERMISSION_MODE:-}" \
+    "${CLAUDE_PERMISSION_MODE:-}" \
+    "${CLAUDE_CODE_PERMISSION_MODE:-}"; do
+    lowered="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+    if [[ "$lowered" == "plan" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+has_ralplan_keyword_signal() {
+  local combined lowered
+  combined="${GUARDEX_WORKFLOW_KEYWORD:-} ${OMX_WORKFLOW_KEYWORD:-} ${OMX_ACTIVE_SKILL:-} ${GUARDEX_ACTIVE_SKILL:-}"
+  lowered="$(printf '%s' "$combined" | tr '[:upper:]' '[:lower:]')"
+  [[ "$lowered" == *ralplan* ]]
+}
+
+recent_active_ralplan_state_exists() {
+  local root="$1"
+  local sessions_dir="${root}/.omx/state/sessions"
+  local now path mtime
+  if [[ ! -d "$sessions_dir" ]]; then
+    return 1
+  fi
+
+  now="$(date +%s)"
+  while IFS= read -r -d '' path; do
+    if ! grep -Eq '"active"[[:space:]]*:[[:space:]]*true' "$path"; then
+      continue
+    fi
+
+    mtime="$(stat -c %Y "$path" 2>/dev/null || stat -f %m "$path" 2>/dev/null || echo 0)"
+    if [[ "$mtime" =~ ^[0-9]+$ ]] && (( now - mtime <= 21600 )); then
+      return 0
+    fi
+  done < <(find "$sessions_dir" -maxdepth 2 -type f -name 'ralplan-state.json' -print0 2>/dev/null)
+
+  return 1
+}
+
+resolve_plan_mode_enabled() {
+  local root="$1"
+  if [[ "$PLAN_MODE_EXPLICIT" -eq 1 ]]; then
+    normalize_bool "$PLAN_MODE_RAW" "0"
+    return 0
+  fi
+
+  if [[ -n "$PLAN_MODE_RAW" ]]; then
+    normalize_bool "$PLAN_MODE_RAW" "0"
+    return 0
+  fi
+
+  if is_plan_permission_mode || has_ralplan_keyword_signal || recent_active_ralplan_state_exists "$root"; then
+    printf '1'
+    return 0
+  fi
+
+  printf '0'
 }
 
 OPENSPEC_AUTO_INIT="$(normalize_bool "$OPENSPEC_AUTO_INIT_RAW" "1")"
@@ -788,6 +866,105 @@ EOF
   echo "[agent-branch-start] Mem0 worktree memory: ${mem0_dir}"
 }
 
+PLAN_MODE_FILE_REL_PATH=""
+
+initialize_plan_mode_markdown() {
+  local worktree="$1"
+  local task_name="$2"
+  local task_slug="$3"
+  local branch_name="$4"
+  local base_branch="$5"
+
+  if [[ "$PLAN_MODE" -ne 1 ]]; then
+    return 0
+  fi
+
+  local plans_dir="${worktree}/.omx/plans"
+  local date_prefix file_name candidate_path suffix
+
+  mkdir -p "$plans_dir"
+
+  date_prefix="$(date +%Y-%m-%d)"
+  file_name="${date_prefix}-${task_slug}.md"
+  candidate_path="${plans_dir}/${file_name}"
+  suffix=2
+  while [[ -e "$candidate_path" ]]; do
+    file_name="${date_prefix}-${task_slug}-${suffix}.md"
+    candidate_path="${plans_dir}/${file_name}"
+    suffix=$((suffix + 1))
+  done
+
+  cat >"$candidate_path" <<EOF
+# PRD: ${task_name}
+
+> 4 phases · estimate pending · persists across sessions
+> Branch: \`${branch_name}\`
+> Base: \`${base_branch}\`
+
+## 1. Problem
+
+Describe the concrete problem and current failure/symptom.
+
+## 2. Goal
+
+Deliver a safe, reversible implementation plan that can be executed phase-by-phase.
+
+## 3. Scope
+
+1. Define the behavior and boundaries for this change.
+2. List the code paths/modules expected to change.
+3. Record verification expectations before implementation begins.
+
+## 4. Non-Goals
+
+1. Avoid unrelated refactors while in plan mode.
+2. Do not cut over destructive changes until shadow validation passes.
+
+## 5. Phased Backlog
+
+### Phase 1 — Discovery + Read-only Mapping (45m · 3 files)
+
+- Map current implementation and dependent callers.
+- Capture constraints and rollout guardrails.
+
+### Phase 2 — Plan Skeleton + Flags (30m · 2 files)
+
+- Define switch/feature-flag strategy and fallback path.
+- Document acceptance checks per caller surface.
+
+### Phase 3 — Shadow Validation (24h observe · 1 file)
+
+- Run old/new paths in parallel and log output diffs.
+- Load-test critical path (for example: 100 concurrent reads).
+
+### Phase 4 — Cutover + Cleanup (1h · 4 files) [deferred]
+
+- Flip default path after shadow window is clean.
+- Remove deprecated fallback implementation in a follow-up PR.
+
+## 6. Acceptance Criteria
+
+1. Plan includes explicit phase boundaries and success signals.
+2. Verification steps are concrete and runnable.
+3. Rollback path is documented before cutover.
+
+## 7. Risks and Mitigations
+
+1. Risk: drift between plan and execution.
+Mitigation: revise this file before each phase starts.
+2. Risk: hidden dependency callers.
+Mitigation: add caller inventory during phase 1.
+
+## 8. Rollout Strategy
+
+1. Keep execution behind explicit approvals for each phase.
+2. Keep phase 4 deferred until validation evidence is green.
+3. Capture final evidence and lessons learned in the completion handoff.
+EOF
+
+  PLAN_MODE_FILE_REL_PATH=".omx/plans/${file_name}"
+}
+
 run_startup_context_artifacts() {
   local repo="$1"
   local worktree="$2"
@@ -943,8 +1120,12 @@ if [[ "$BASE_BRANCH_EXPLICIT" -eq 0 ]]; then
   fi
 fi
 
+PLAN_MODE="$(resolve_plan_mode_enabled "$repo_root")"
 task_slug="$(sanitize_slug "$TASK_NAME" "task")"
 agent_slug="$(normalize_role "$AGENT_NAME")"
+if [[ "$PLAN_MODE" -eq 1 ]]; then
+  agent_slug="plan"
+fi
 branch_timestamp="$(compose_branch_timestamp)"
 branch_descriptor="$(compose_branch_descriptor "$task_slug" "$branch_timestamp")"
 branch_name_base="agent/${agent_slug}/${branch_descriptor}"
@@ -1041,6 +1222,7 @@ if [[ "$reused_existing_worktree" -eq 0 ]]; then
   fi
 fi
 initialize_worktree_mem0_layer "$worktree_path" "$branch_name" "$BASE_BRANCH" "$task_slug" "$agent_slug"
+initialize_plan_mode_markdown "$worktree_path" "$TASK_NAME" "$task_slug" "$branch_name" "$BASE_BRANCH"
 
 run_startup_context_artifacts "$repo_root" "$worktree_path" "$branch_name" "$BASE_BRANCH" "$PR_REF" "$GH_REPO_REF"
 record_worktree_bootstrap_manifest "$worktree_path" "$branch_name" "$BASE_BRANCH" "$openspec_change_slug" "$openspec_plan_slug"
@@ -1064,6 +1246,12 @@ if [[ "$helper_branch_assist_mode" -eq 1 ]]; then
 else
   echo "[agent-branch-start] OpenSpec change: openspec/changes/${openspec_change_slug}"
   echo "[agent-branch-start] OpenSpec plan: openspec/plan/${openspec_plan_slug}"
+fi
+if [[ "$PLAN_MODE" -eq 1 ]]; then
+  echo "[agent-branch-start] Plan mode: ON (agent/plan/* branch)"
+  if [[ -n "$PLAN_MODE_FILE_REL_PATH" ]]; then
+    echo "[agent-branch-start] Plan file: ${PLAN_MODE_FILE_REL_PATH}"
+  fi
 fi
 echo "[agent-branch-start] Next steps:"
 echo "  cd \"${worktree_path}\""

--- a/scripts/codex-agent.sh
+++ b/scripts/codex-agent.sh
@@ -9,6 +9,7 @@ CODEX_BIN="${GUARDEX_CODEX_BIN:-codex}"
 GH_PR_REF="${GUARDEX_GH_PR_REF:-}"
 GH_REPO_REF="${GUARDEX_GH_REPO:-}"
 GH_SYNC_FLAG=""
+PLAN_MODE_START=0
 
 if [[ -n "$BASE_BRANCH" ]]; then
   BASE_BRANCH_EXPLICIT=1
@@ -90,6 +91,35 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 repo_root="$(git rev-parse --show-toplevel)"
 
+normalize_bool() {
+  local raw="${1:-}"
+  local fallback="${2:-0}"
+  local lowered
+  lowered="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  case "$lowered" in
+    1|true|yes|on) printf '1' ;;
+    0|false|no|off) printf '0' ;;
+    '') printf '%s' "$fallback" ;;
+    *) printf '%s' "$fallback" ;;
+  esac
+}
+
+has_plan_permission_arg() {
+  local previous=""
+  local arg lowered
+  for arg in "$@"; do
+    lowered="$(printf '%s' "$arg" | tr '[:upper:]' '[:lower:]')"
+    if [[ "$lowered" == "--permission-mode=plan" || "$lowered" == "--plan-mode" ]]; then
+      return 0
+    fi
+    if [[ "$previous" == "--permission-mode" && "$lowered" == "plan" ]]; then
+      return 0
+    fi
+    previous="$lowered"
+  done
+  return 1
+}
+
 if [[ ! -x "${repo_root}/scripts/agent-branch-start.sh" ]]; then
   echo "[codex-agent] Missing scripts/agent-branch-start.sh. Run: gx setup" >&2
   exit 1
@@ -107,6 +137,10 @@ if [[ -n "$GH_REPO_REF" ]]; then
 fi
 if [[ -n "$GH_SYNC_FLAG" ]]; then
   start_args+=("$GH_SYNC_FLAG")
+fi
+if [[ "$(normalize_bool "${GX_PLAN_MODE:-${GUARDEX_PLAN_MODE:-}}" "0")" -eq 1 ]] || has_plan_permission_arg "$@"; then
+  PLAN_MODE_START=1
+  start_args+=(--plan-mode)
 fi
 
 derive_worktree_session_key() {

--- a/templates/scripts/agent-branch-start.sh
+++ b/templates/scripts/agent-branch-start.sh
@@ -10,6 +10,8 @@ OPENSPEC_AUTO_INIT_RAW="${GUARDEX_OPENSPEC_AUTO_INIT:-false}"
 OPENSPEC_PLAN_SLUG_OVERRIDE="${GUARDEX_OPENSPEC_PLAN_SLUG:-}"
 OPENSPEC_CHANGE_SLUG_OVERRIDE="${GUARDEX_OPENSPEC_CHANGE_SLUG:-}"
 OPENSPEC_CAPABILITY_SLUG_OVERRIDE="${GUARDEX_OPENSPEC_CAPABILITY_SLUG:-}"
+PLAN_MODE_RAW="${GX_PLAN_MODE:-${GUARDEX_PLAN_MODE:-}}"
+PLAN_MODE_EXPLICIT=0
 PRINT_NAME_ONLY=0
 POSITIONAL_ARGS=()
 
@@ -30,6 +32,16 @@ while [[ $# -gt 0 ]]; do
       ;;
     --print-name-only)
       PRINT_NAME_ONLY=1
+      shift
+      ;;
+    --plan-mode)
+      PLAN_MODE_RAW="true"
+      PLAN_MODE_EXPLICIT=1
+      shift
+      ;;
+    --no-plan-mode)
+      PLAN_MODE_RAW="false"
+      PLAN_MODE_EXPLICIT=1
       shift
       ;;
     --tier)
@@ -56,7 +68,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     -*)
       echo "[agent-branch-start] Unknown option: $1" >&2
-      echo "Usage: $0 [task] [agent] [base] [--worktree-root <path>] [--print-name-only]" >&2
+      echo "Usage: $0 [task] [agent] [base] [--worktree-root <path>] [--plan-mode|--no-plan-mode] [--print-name-only]" >&2
       exit 1
       ;;
     *)
@@ -68,7 +80,7 @@ done
 
 if [[ "${#POSITIONAL_ARGS[@]}" -gt 3 ]]; then
   echo "[agent-branch-start] Too many positional arguments." >&2
-  echo "Usage: $0 [task] [agent] [base] [--worktree-root <path>]" >&2
+  echo "Usage: $0 [task] [agent] [base] [--worktree-root <path>] [--plan-mode|--no-plan-mode]" >&2
   exit 1
 fi
 
@@ -188,6 +200,72 @@ normalize_bool() {
     '') printf '%s' "$fallback" ;;
     *) printf '%s' "$fallback" ;;
   esac
+}
+
+is_plan_permission_mode() {
+  local raw lowered
+  for raw in \
+    "${GUARDEX_PERMISSION_MODE:-}" \
+    "${OMX_PERMISSION_MODE:-}" \
+    "${CODEX_PERMISSION_MODE:-}" \
+    "${CLAUDE_PERMISSION_MODE:-}" \
+    "${CLAUDE_CODE_PERMISSION_MODE:-}"; do
+    lowered="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+    if [[ "$lowered" == "plan" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+has_ralplan_keyword_signal() {
+  local combined lowered
+  combined="${GUARDEX_WORKFLOW_KEYWORD:-} ${OMX_WORKFLOW_KEYWORD:-} ${OMX_ACTIVE_SKILL:-} ${GUARDEX_ACTIVE_SKILL:-}"
+  lowered="$(printf '%s' "$combined" | tr '[:upper:]' '[:lower:]')"
+  [[ "$lowered" == *ralplan* ]]
+}
+
+recent_active_ralplan_state_exists() {
+  local root="$1"
+  local sessions_dir="${root}/.omx/state/sessions"
+  local now path mtime
+  if [[ ! -d "$sessions_dir" ]]; then
+    return 1
+  fi
+
+  now="$(date +%s)"
+  while IFS= read -r -d '' path; do
+    if ! grep -Eq '"active"[[:space:]]*:[[:space:]]*true' "$path"; then
+      continue
+    fi
+
+    mtime="$(stat -c %Y "$path" 2>/dev/null || stat -f %m "$path" 2>/dev/null || echo 0)"
+    if [[ "$mtime" =~ ^[0-9]+$ ]] && (( now - mtime <= 21600 )); then
+      return 0
+    fi
+  done < <(find "$sessions_dir" -maxdepth 2 -type f -name 'ralplan-state.json' -print0 2>/dev/null)
+
+  return 1
+}
+
+resolve_plan_mode_enabled() {
+  local root="$1"
+  if [[ "$PLAN_MODE_EXPLICIT" -eq 1 ]]; then
+    normalize_bool "$PLAN_MODE_RAW" "0"
+    return 0
+  fi
+
+  if [[ -n "$PLAN_MODE_RAW" ]]; then
+    normalize_bool "$PLAN_MODE_RAW" "0"
+    return 0
+  fi
+
+  if is_plan_permission_mode || has_ralplan_keyword_signal || recent_active_ralplan_state_exists "$root"; then
+    printf '1'
+    return 0
+  fi
+
+  printf '0'
 }
 
 OPENSPEC_AUTO_INIT="$(normalize_bool "$OPENSPEC_AUTO_INIT_RAW" "1")"
@@ -382,6 +460,105 @@ initialize_openspec_change_workspace() {
   echo "[agent-branch-start] OpenSpec change workspace: ${worktree}/openspec/changes/${change_slug}"
 }
 
+PLAN_MODE_FILE_REL_PATH=""
+
+initialize_plan_mode_markdown() {
+  local worktree="$1"
+  local task_name="$2"
+  local task_slug="$3"
+  local branch_name="$4"
+  local base_branch="$5"
+
+  if [[ "$PLAN_MODE" -ne 1 ]]; then
+    return 0
+  fi
+
+  local plans_dir="${worktree}/.omx/plans"
+  local date_prefix file_name candidate_path suffix
+
+  mkdir -p "$plans_dir"
+
+  date_prefix="$(date +%Y-%m-%d)"
+  file_name="${date_prefix}-${task_slug}.md"
+  candidate_path="${plans_dir}/${file_name}"
+  suffix=2
+  while [[ -e "$candidate_path" ]]; do
+    file_name="${date_prefix}-${task_slug}-${suffix}.md"
+    candidate_path="${plans_dir}/${file_name}"
+    suffix=$((suffix + 1))
+  done
+
+  cat >"$candidate_path" <<EOF
+# PRD: ${task_name}
+
+> 4 phases · estimate pending · persists across sessions
+> Branch: \`${branch_name}\`
+> Base: \`${base_branch}\`
+
+## 1. Problem
+
+Describe the concrete problem and current failure/symptom.
+
+## 2. Goal
+
+Deliver a safe, reversible implementation plan that can be executed phase-by-phase.
+
+## 3. Scope
+
+1. Define the behavior and boundaries for this change.
+2. List the code paths/modules expected to change.
+3. Record verification expectations before implementation begins.
+
+## 4. Non-Goals
+
+1. Avoid unrelated refactors while in plan mode.
+2. Do not cut over destructive changes until shadow validation passes.
+
+## 5. Phased Backlog
+
+### Phase 1 — Discovery + Read-only Mapping (45m · 3 files)
+
+- Map current implementation and dependent callers.
+- Capture constraints and rollout guardrails.
+
+### Phase 2 — Plan Skeleton + Flags (30m · 2 files)
+
+- Define switch/feature-flag strategy and fallback path.
+- Document acceptance checks per caller surface.
+
+### Phase 3 — Shadow Validation (24h observe · 1 file)
+
+- Run old/new paths in parallel and log output diffs.
+- Load-test critical path (for example: 100 concurrent reads).
+
+### Phase 4 — Cutover + Cleanup (1h · 4 files) [deferred]
+
+- Flip default path after shadow window is clean.
+- Remove deprecated fallback implementation in a follow-up PR.
+
+## 6. Acceptance Criteria
+
+1. Plan includes explicit phase boundaries and success signals.
+2. Verification steps are concrete and runnable.
+3. Rollback path is documented before cutover.
+
+## 7. Risks and Mitigations
+
+1. Risk: drift between plan and execution.
+Mitigation: revise this file before each phase starts.
+2. Risk: hidden dependency callers.
+Mitigation: add caller inventory during phase 1.
+
+## 8. Rollout Strategy
+
+1. Keep execution behind explicit approvals for each phase.
+2. Keep phase 4 deferred until validation evidence is green.
+3. Capture final evidence and lessons learned in the completion handoff.
+EOF
+
+  PLAN_MODE_FILE_REL_PATH=".omx/plans/${file_name}"
+}
+
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "[agent-branch-start] Not inside a git repository." >&2
   exit 1
@@ -394,8 +571,12 @@ if [[ "$BASE_BRANCH_EXPLICIT" -eq 1 && -z "$BASE_BRANCH" ]]; then
   exit 1
 fi
 
+PLAN_MODE="$(resolve_plan_mode_enabled "$repo_root")"
 task_slug="$(sanitize_slug "$TASK_NAME" "task")"
 agent_slug="$(normalize_role "$AGENT_NAME")"
+if [[ "$PLAN_MODE" -eq 1 ]]; then
+  agent_slug="plan"
+fi
 branch_timestamp="$(compose_branch_timestamp)"
 branch_descriptor="$(compose_branch_descriptor "$task_slug" "$branch_timestamp")"
 branch_name_base="agent/${agent_slug}/${branch_descriptor}"
@@ -505,11 +686,18 @@ fi
 if ! initialize_openspec_plan_workspace "$repo_root" "$worktree_path" "$openspec_plan_slug"; then
   exit 1
 fi
+initialize_plan_mode_markdown "$worktree_path" "$TASK_NAME" "$task_slug" "$branch_name" "$BASE_BRANCH"
 
 echo "[agent-branch-start] Created branch: ${branch_name}"
 echo "[agent-branch-start] Worktree: ${worktree_path}"
 echo "[agent-branch-start] OpenSpec change: openspec/changes/${openspec_change_slug}"
 echo "[agent-branch-start] OpenSpec plan: openspec/plan/${openspec_plan_slug}"
+if [[ "$PLAN_MODE" -eq 1 ]]; then
+  echo "[agent-branch-start] Plan mode: ON (agent/plan/* branch)"
+  if [[ -n "$PLAN_MODE_FILE_REL_PATH" ]]; then
+    echo "[agent-branch-start] Plan file: ${PLAN_MODE_FILE_REL_PATH}"
+  fi
+fi
 echo "[agent-branch-start] Next steps:"
 echo "  cd \"${worktree_path}\""
 echo "  python3 scripts/agent-file-locks.py claim --branch \"${branch_name}\" <file...>"

--- a/templates/scripts/codex-agent.sh
+++ b/templates/scripts/codex-agent.sh
@@ -14,6 +14,7 @@ OPENSPEC_AUTO_INIT_RAW="${GUARDEX_OPENSPEC_AUTO_INIT:-true}"
 OPENSPEC_PLAN_SLUG_OVERRIDE="${GUARDEX_OPENSPEC_PLAN_SLUG:-}"
 OPENSPEC_CHANGE_SLUG_OVERRIDE="${GUARDEX_OPENSPEC_CHANGE_SLUG:-}"
 OPENSPEC_CAPABILITY_SLUG_OVERRIDE="${GUARDEX_OPENSPEC_CAPABILITY_SLUG:-}"
+PLAN_MODE_START=0
 
 normalize_bool() {
   local raw="${1:-}"
@@ -26,6 +27,22 @@ normalize_bool() {
     '') printf '%s' "$fallback" ;;
     *) printf '%s' "$fallback" ;;
   esac
+}
+
+has_plan_permission_arg() {
+  local previous=""
+  local arg lowered
+  for arg in "$@"; do
+    lowered="$(printf '%s' "$arg" | tr '[:upper:]' '[:lower:]')"
+    if [[ "$lowered" == "--permission-mode=plan" || "$lowered" == "--plan-mode" ]]; then
+      return 0
+    fi
+    if [[ "$previous" == "--permission-mode" && "$lowered" == "plan" ]]; then
+      return 0
+    fi
+    previous="$lowered"
+  done
+  return 1
 }
 
 AUTO_FINISH="$(normalize_bool "$AUTO_FINISH_RAW" "1")"
@@ -257,7 +274,11 @@ start_sandbox_fallback() {
 
   timestamp="$(date +%Y%m%d-%H%M%S)"
   task_slug="$(sanitize_slug "$TASK_NAME" "task")"
-  agent_slug="$(sanitize_slug "$AGENT_NAME" "agent")"
+  if [[ "$PLAN_MODE_START" -eq 1 ]]; then
+    agent_slug="plan"
+  else
+    agent_slug="$(sanitize_slug "$AGENT_NAME" "agent")"
+  fi
   branch_name_base="agent/${agent_slug}/${timestamp}-${task_slug}"
   branch_name="$branch_name_base"
   suffix=2
@@ -292,6 +313,10 @@ fi
 start_args=("$TASK_NAME" "$AGENT_NAME")
 if [[ "$BASE_BRANCH_EXPLICIT" -eq 1 ]]; then
   start_args+=("$BASE_BRANCH")
+fi
+if [[ "$(normalize_bool "${GX_PLAN_MODE:-${GUARDEX_PLAN_MODE:-}}" "0")" -eq 1 ]] || has_plan_permission_arg "$@"; then
+  PLAN_MODE_START=1
+  start_args+=(--plan-mode)
 fi
 
 initial_repo_branch="$(git -C "$repo_root" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -215,6 +215,12 @@ function extractOpenSpecChangeSlug(output) {
   return match[1].trim();
 }
 
+function extractPlanFilePath(output) {
+  const match = String(output || '').match(/\[agent-branch-start\] Plan file: (.+)/);
+  assert.ok(match, `missing plan file path in output: ${output}`);
+  return match[1].trim();
+}
+
 function extractHookCommands(settings) {
   const hooks = settings && typeof settings === 'object' ? settings.hooks : null;
   if (!hooks || typeof hooks !== 'object') {
@@ -1290,6 +1296,52 @@ test('setup agent-branch-start keeps role-datetime branch labels compact (v7.0.3
   assert.ok(branchLeaf.length <= 90, `branch leaf should stay compact, got: ${branchLeaf}`);
   // Snapshot name and account email fragments must not leak into the leaf.
   assert.doesNotMatch(branchLeaf, /zeus|portasmosonma|admin-recodee/);
+});
+
+test('setup agent-branch-start plan mode creates agent/plan branch and .omx plans markdown', () => {
+  const repoDir = initRepo();
+
+  let result = runNode(['setup', '--target', repoDir], repoDir);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  seedCommit(repoDir);
+
+  result = runCmd(
+    'bash',
+    ['scripts/agent-branch-start.sh', 'dashboard-rust-port', 'planner', 'dev', '--plan-mode'],
+    repoDir,
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  const createdBranch = extractCreatedBranch(result.stdout);
+  const createdWorktree = extractCreatedWorktree(result.stdout);
+  const planFileRel = extractPlanFilePath(result.stdout);
+  const planFileAbs = path.join(createdWorktree, planFileRel);
+
+  assert.match(createdBranch, /^agent\/plan\/dashboard-rust-port-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}$/);
+  assert.equal(fs.existsSync(planFileAbs), true, `missing plan markdown: ${planFileAbs}`);
+  const planContent = fs.readFileSync(planFileAbs, 'utf8');
+  assert.match(planContent, /^# PRD: dashboard-rust-port/m);
+  assert.match(planContent, /^## 5\. Phased Backlog/m);
+  assert.match(planContent, /^### Phase 1 — Discovery \+ Read-only Mapping/m);
+});
+
+test('setup agent-branch-start auto-enters plan mode from Claude plan permission env', () => {
+  const repoDir = initRepo();
+
+  let result = runNode(['setup', '--target', repoDir], repoDir);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  seedCommit(repoDir);
+
+  result = runCmd(
+    'bash',
+    ['scripts/agent-branch-start.sh', 'inventory-slice', 'planner', 'dev'],
+    repoDir,
+    { env: { CLAUDE_PERMISSION_MODE: 'plan' } },
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const createdBranch = extractCreatedBranch(result.stdout);
+  assert.match(createdBranch, /^agent\/plan\/inventory-slice-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}$/);
+  assert.match(result.stdout, /\[agent-branch-start\] Plan mode: ON \(agent\/plan\/\* branch\)/);
 });
 
 test('setup agent-branch-start supports optional OpenSpec auto-bootstrap toggles', () => {
@@ -2494,6 +2546,48 @@ test('codex-agent launches codex inside a fresh sandbox worktree and keeps branc
     true,
     'codex-agent should scaffold OpenSpec change spec in sandbox',
   );
+});
+
+test('codex-agent forwards --permission-mode plan to plan-mode sandbox branch start', () => {
+  const repoDir = initRepo();
+  seedCommit(repoDir);
+
+  const setupResult = runNode(['setup', '--target', repoDir, '--no-global-install'], repoDir);
+  assert.equal(setupResult.status, 0, setupResult.stderr || setupResult.stdout);
+  let result = runCmd('git', ['add', '.'], repoDir);
+  assert.equal(result.status, 0, result.stderr);
+  result = runCmd('git', ['commit', '-m', 'apply gx setup'], repoDir, {
+    ALLOW_COMMIT_ON_PROTECTED_BRANCH: '1',
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'guardex-fake-codex-plan-'));
+  const fakeCodexPath = path.join(fakeBin, 'codex');
+  fs.writeFileSync(
+    fakeCodexPath,
+    `#!/usr/bin/env bash\n` +
+      `pwd > "${'${GUARDEX_TEST_CODEX_CWD}'}"\n` +
+      `echo "$@" > "${'${GUARDEX_TEST_CODEX_ARGS}'}"\n`,
+    'utf8',
+  );
+  fs.chmodSync(fakeCodexPath, 0o755);
+
+  const cwdMarker = path.join(repoDir, '.codex-agent-plan-cwd');
+  const argsMarker = path.join(repoDir, '.codex-agent-plan-args');
+  const launch = runCmd(
+    'bash',
+    ['scripts/codex-agent.sh', 'dashboard-rust-port', 'planner', 'dev', '--permission-mode', 'plan'],
+    repoDir,
+    {
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      GUARDEX_TEST_CODEX_CWD: cwdMarker,
+      GUARDEX_TEST_CODEX_ARGS: argsMarker,
+    },
+  );
+  assert.equal(launch.status, 0, launch.stderr || launch.stdout);
+  const launchedBranch = extractCreatedBranch(launch.stdout);
+  assert.match(launchedBranch, /^agent\/plan\/[a-z0-9-]+-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}$/);
+  assert.match(launch.stdout, /\[agent-branch-start\] Plan mode: ON \(agent\/plan\/\* branch\)/);
 });
 
 test('codex-agent restores local branch and falls back to safe worktree start when starter script switches in-place', () => {


### PR DESCRIPTION
## Summary
- add plan-mode detection to agent branch start (flags, permission-mode env, ralplan hints)
- when plan mode is active, create  sandboxes (still inside  guardrails)
- generate  PRD + phased backlog draft on each plan-mode start
- forward  from codex-agent into starter 
- add regression tests and OpenSpec change docs for the new behavior

## Verification
- 
- manual temp-repo run: [agent-branch-start] Using current agent branch 'agent/codex/plan-mode-agent-plan-branch-and-md-2026-04-20-08-57' as helper base.
[agent-branch-start] Helper branch base 'agent/codex/plan-mode-agent-plan-branch-and-md-2026-04-20-08-57' detected; skipping OpenSpec auto-init for joined-agent assist.
branch 'agent/plan/task-2026-04-20-09-10' set up to track 'origin/agent/codex/plan-mode-agent-plan-branch-and-md-2026-04-20-08-57'.
HEAD is now at 28531e5 Document plan-mode branch and persisted PRD behavior in OpenSpec artifacts
[agent-branch-start] Linked dependency dir in worktree: node_modules
[agent-branch-start] Mem0 worktree memory: /home/deadpool/Documents/recodee/guardex-agent-work-tree-managment/.omx/agent-worktrees/agent__codex__plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/.omx/agent-worktrees/agent__plan__task-2026-04-20-09-10/.omx/mem0
[agent-branch-start] Startup metadata: /home/deadpool/Documents/recodee/guardex-agent-work-tree-managment/.omx/agent-worktrees/agent__codex__plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/.omx/agent-worktrees/agent__plan__task-2026-04-20-09-10/.omx/context/github/sandbox-startup-latest.json
[agent-branch-start] Bootstrap manifest: /home/deadpool/Documents/recodee/guardex-agent-work-tree-managment/.git/worktrees/agent__plan__task-2026-04-20-09-10/guardex-bootstrap-manifest.json
[agent-branch-start] Created branch: agent/plan/task-2026-04-20-09-10
[agent-branch-start] Worktree: /home/deadpool/Documents/recodee/guardex-agent-work-tree-managment/.omx/agent-worktrees/agent__codex__plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/.omx/agent-worktrees/agent__plan__task-2026-04-20-09-10
[agent-branch-start] OpenSpec change: skipped (helper branch assisting agent/codex/plan-mode-agent-plan-branch-and-md-2026-04-20-08-57)
[agent-branch-start] OpenSpec plan: skipped (helper branch assisting agent/codex/plan-mode-agent-plan-branch-and-md-2026-04-20-08-57)
[agent-branch-start] Plan mode: ON (agent/plan/* branch)
[agent-branch-start] Plan file: .omx/plans/2026-04-20-task.md
[agent-branch-start] Next steps:
  cd "/home/deadpool/Documents/recodee/guardex-agent-work-tree-managment/.omx/agent-worktrees/agent__codex__plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/.omx/agent-worktrees/agent__plan__task-2026-04-20-09-10"
  python3 scripts/agent-file-locks.py claim --branch "agent/plan/task-2026-04-20-09-10" <file...>
  # implement + commit
  bash scripts/agent-branch-finish.sh --branch "agent/plan/task-2026-04-20-09-10" --base agent/codex/plan-mode-agent-plan-branch-and-md-2026-04-20-08-57 --via-pr --wait-for-merge ->  + 
- manual temp-repo run: [agent-branch-start] Using current agent branch 'agent/codex/plan-mode-agent-plan-branch-and-md-2026-04-20-08-57' as helper base.
[agent-branch-start] Helper branch base 'agent/codex/plan-mode-agent-plan-branch-and-md-2026-04-20-08-57' detected; skipping OpenSpec auto-init for joined-agent assist.
[agent-branch-start] Reusing untouched sandbox branch/worktree: agent/plan/task-2026-04-20-09-10 (/home/deadpool/Documents/recodee/guardex-agent-work-tree-managment/.omx/agent-worktrees/agent__codex__plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/.omx/agent-worktrees/agent__plan__task-2026-04-20-09-10)
[agent-branch-start] Mem0 worktree memory: /home/deadpool/Documents/recodee/guardex-agent-work-tree-managment/.omx/agent-worktrees/agent__codex__plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/.omx/agent-worktrees/agent__plan__task-2026-04-20-09-10/.omx/mem0
[agent-branch-start] Startup metadata: /home/deadpool/Documents/recodee/guardex-agent-work-tree-managment/.omx/agent-worktrees/agent__codex__plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/.omx/agent-worktrees/agent__plan__task-2026-04-20-09-10/.omx/context/github/sandbox-startup-latest.json
[agent-branch-start] Bootstrap manifest: /home/deadpool/Documents/recodee/guardex-agent-work-tree-managment/.git/worktrees/agent__plan__task-2026-04-20-09-10/guardex-bootstrap-manifest.json
[agent-branch-start] Created branch: agent/plan/task-2026-04-20-09-10
[agent-branch-start] Worktree: /home/deadpool/Documents/recodee/guardex-agent-work-tree-managment/.omx/agent-worktrees/agent__codex__plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/.omx/agent-worktrees/agent__plan__task-2026-04-20-09-10
[agent-branch-start] OpenSpec change: skipped (helper branch assisting agent/codex/plan-mode-agent-plan-branch-and-md-2026-04-20-08-57)
[agent-branch-start] OpenSpec plan: skipped (helper branch assisting agent/codex/plan-mode-agent-plan-branch-and-md-2026-04-20-08-57)
[agent-branch-start] Plan mode: ON (agent/plan/* branch)
[agent-branch-start] Plan file: .omx/plans/2026-04-20-task-2.md
[agent-branch-start] Next steps:
  cd "/home/deadpool/Documents/recodee/guardex-agent-work-tree-managment/.omx/agent-worktrees/agent__codex__plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/.omx/agent-worktrees/agent__plan__task-2026-04-20-09-10"
  python3 scripts/agent-file-locks.py claim --branch "agent/plan/task-2026-04-20-09-10" <file...>
  # implement + commit
  bash scripts/agent-branch-finish.sh --branch "agent/plan/task-2026-04-20-09-10" --base agent/codex/plan-mode-agent-plan-branch-and-md-2026-04-20-08-57 --via-pr --wait-for-merge
[codex-agent] Scoped CODEX_AUTH_SESSION_KEY to worktree:27d097d16570752e1150
[codex-agent] Worktree mem0 scope: /home/deadpool/Documents/recodee/guardex-agent-work-tree-managment/.omx/agent-worktrees/agent__codex__plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/.omx/agent-worktrees/agent__plan__task-2026-04-20-09-10/.omx/mem0
[codex-agent] Launching codex in sandbox: /home/deadpool/Documents/recodee/guardex-agent-work-tree-managment/.omx/agent-worktrees/agent__codex__plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/.omx/agent-worktrees/agent__plan__task-2026-04-20-09-10
[codex-agent] Skipping auto-finish because Codex exited with status 2.
[codex-agent] Session ended (exit=2). Running worktree cleanup...
[agent-worktree-prune] Skipping active cwd worktree: /home/deadpool/Documents/recodee/guardex-agent-work-tree-managment/.omx/agent-worktrees/agent__codex__plan-mode-agent-plan-branch-and-md-2026-04-20-08-57
[agent-worktree-prune] Summary: base=main, removed_worktrees=0, removed_branches=0, skipped_active=1, skipped_dirty=0, repaired_detached_conflicts=0
[codex-agent] Sandbox worktree kept: /home/deadpool/Documents/recodee/guardex-agent-work-tree-managment/.omx/agent-worktrees/agent__codex__plan-mode-agent-plan-branch-and-md-2026-04-20-08-57/.omx/agent-worktrees/agent__plan__task-2026-04-20-09-10
[codex-agent] If finished, merge + clean with: bash scripts/agent-branch-finish.sh --branch "agent/plan/task-2026-04-20-09-10" --base "agent/codex/plan-mode-agent-plan-branch-and-md-2026-04-20-08-57" --via-pr --wait-for-merge --cleanup -> 
- Change 'agent-codex-plan-mode-agent-plan-branch-and-md-2026-04-20-08-57' is valid
- No items found to validate.