### PR TITLE
Bump Guardex to v7.0.4 for npm publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,11 @@ npm pack --dry-run
 
 ## Release notes
 
+### v7.0.4
+
+- **Fixed: publish collision on npm.** Advanced the package metadata from `7.0.3` to `7.0.4` so `npm publish` no longer targets an already published version.
+- **Changed: release-note sync for versioning rule.** Added this versioned entry in README in the same change as the package bump to keep publish metadata and release notes aligned.
+
 ### v7.0.3
 
 - **Branch/worktree naming refactor.** `agent-branch-start.sh` now produces `agent/<role>/<task>-<YYYY-MM-DD>-<HH-MM>` instead of `agent/<role+account-email>/<snapshot-slug>-<task>-<cksum6>`. Codex account names (e.g. `Zeus Edix Hu`) and 6-hex checksums no longer leak into branch or worktree paths.

--- a/openspec/changes/agent-codex-bump-version-7-0-4-2026-04-20-09-13/.openspec.yaml
+++ b/openspec/changes/agent-codex-bump-version-7-0-4-2026-04-20-09-13/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-20

--- a/openspec/changes/agent-codex-bump-version-7-0-4-2026-04-20-09-13/proposal.md
+++ b/openspec/changes/agent-codex-bump-version-7-0-4-2026-04-20-09-13/proposal.md
@@ -1,0 +1,14 @@
+## Why
+
+- `npm publish` failed because `@imdeadpool/guardex@7.0.3` is already published.
+- The repo versioning rule requires release notes to be updated in README whenever publish/version metadata changes.
+
+## What Changes
+
+- Bump package version from `7.0.3` to `7.0.4` in package metadata.
+- Add a `v7.0.4` release-note entry to README describing the publish-collision fix and release-note sync.
+
+## Impact
+
+- Affects npm release metadata and release-note documentation only.
+- Low risk: no runtime behavior changes.

--- a/openspec/changes/agent-codex-bump-version-7-0-4-2026-04-20-09-13/specs/bump-version-7-0-4/spec.md
+++ b/openspec/changes/agent-codex-bump-version-7-0-4-2026-04-20-09-13/specs/bump-version-7-0-4/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Publish version must advance past last published release
+When a publish attempt fails due to an already published package version, the repository SHALL advance to the next patch version before retrying publish.
+
+#### Scenario: Duplicate publish version is detected
+- **WHEN** `npm publish` reports that the current version already exists on npm
+- **THEN** package metadata is updated to the next patch version
+- **AND** the new version is present in package metadata before the next publish attempt.
+
+### Requirement: Version bumps must include README release notes
+Any change that updates publish/version metadata SHALL include a matching release-note entry in `README.md`.
+
+#### Scenario: Patch bump prepared for publish
+- **WHEN** the package version is incremented for publish
+- **THEN** `README.md` contains a release-note section for that exact version in the same change.

--- a/openspec/changes/agent-codex-bump-version-7-0-4-2026-04-20-09-13/tasks.md
+++ b/openspec/changes/agent-codex-bump-version-7-0-4-2026-04-20-09-13/tasks.md
@@ -1,0 +1,19 @@
+## 1. Specification
+
+- [x] 1.1 Finalized scope and acceptance criteria for `agent-codex-bump-version-7-0-4-2026-04-20-09-13` around npm publish collision recovery and release-note sync.
+- [x] 1.2 Defined normative requirements in `specs/bump-version-7-0-4/spec.md`.
+
+## 2. Implementation
+
+- [x] 2.1 Bumped package metadata version from `7.0.3` to `7.0.4`.
+- [x] 2.2 Added `README.md` release-note entry for `v7.0.4`.
+
+## 3. Verification
+
+- [x] 3.1 Ran targeted verification commands (`node -p "require('./package.json').version"` and `npm pack --dry-run`) to confirm version metadata and package shape.
+- [x] 3.2 Ran `openspec validate agent-codex-bump-version-7-0-4-2026-04-20-09-13 --type change --strict`.
+- [x] 3.3 Ran `openspec validate --specs`.
+
+## 4. Cleanup
+
+- [x] 4.1 After successful merge, run `bash scripts/agent-worktree-prune.sh --base main --delete-branches --delete-remote-branches` so merged sandbox branch/worktree artifacts are removed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "6.0.1",
+  "version": "7.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@imdeadpool/guardex",
-      "version": "6.0.1",
+      "version": "7.0.4",
       "license": "MIT",
       "bin": {
         "guardex": "bin/multiagent-safety.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "GuardeX: the Guardian T-Rex for your repo, with hardened multi-agent git guardrails.",
   "license": "MIT",
   "preferGlobal": true,


### PR DESCRIPTION
## Summary\n- bump package version from 7.0.3 to 7.0.4 so npm publish is no longer blocked\n- add README release notes entry for v7.0.4 per repo versioning rule\n- include OpenSpec change artifacts for this patch update\n\n## Verification\n- node -p "require('./package.json').version"\n- npm_config_cache=/tmp/.npm-cache npm pack --dry-run\n- openspec validate agent-codex-bump-version-7-0-4-2026-04-20-09-13 --type change --strict\n- openspec validate --specs