### PR TITLE
Add explicit frontend repo links in guardex

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ GuardeX is a safety layer for parallel Codex/agent work in git repos.
 > [!WARNING]
 > Not affiliated with OpenAI or Codex. Not an official tool.
 
+## Frontend Repo
+
+- Standalone frontend repository: https://github.com/Webu-PRO/guardex-frontend
+- This repository tracks/mirrors the frontend under `frontend/` as documented below.
+
 ## The problem (what was going wrong)
 
 Multiple Codex agents worked on the same files at the same time.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,7 @@
+# Frontend Repository Link
+
+Canonical standalone frontend repository:
+
+- https://github.com/Webu-PRO/guardex-frontend
+
+This `frontend/` directory is mirrored/synced with that repository.


### PR DESCRIPTION
## Summary
- add a direct frontend-repo link section in root README
- add frontend/README.md pointer to standalone frontend repository

## Why
- makes the frontend repository discoverable directly from this repo view

## Verification
- docs-only change