### PR TITLE
Keep fresh agent worktrees unpublished until first push

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ gx agents stop
 - Codex/agent sessions stay blocked on protected branches and must use `agent/*` branch + PR workflow.
 - On protected `main`, `gx doctor` auto-runs in a sandbox agent branch/worktree.
 - In-place agent branching is disabled; `scripts/agent-branch-start.sh` always creates a separate worktree to keep your visible local/base branch unchanged.
+- Fresh sandbox branches intentionally start without any git upstream; guardex records the protected base in `branch.<name>.guardexBase`, and the first `git push -u` publishes the real upstream branch.
 - `scripts/agent-branch-start.sh` hydrates `scripts/codex-agent.sh` into new sandbox worktrees when missing, so auto-finish launcher flow stays available.
 
 ## Configure protected branches

--- a/openspec/changes/agent-codex-clear-agent-upstream-on-branch-start-2026-04-20-20-06/.openspec.yaml
+++ b/openspec/changes/agent-codex-clear-agent-upstream-on-branch-start-2026-04-20-20-06/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-20

--- a/openspec/changes/agent-codex-clear-agent-upstream-on-branch-start-2026-04-20-20-06/proposal.md
+++ b/openspec/changes/agent-codex-clear-agent-upstream-on-branch-start-2026-04-20-20-06/proposal.md
@@ -1,0 +1,16 @@
+## Why
+
+- Fresh `agent/*` worktrees inherit `origin/<base>` as their upstream when they are created from a protected branch.
+- That makes unpublished sandbox branches look divergent from `main`/`dev`, and VS Code `Sync Changes` tries to pull the protected base branch instead of waiting for the first `git push -u`.
+
+## What Changes
+
+- Update `scripts/agent-branch-start.sh` and its template so new agent branches start without any upstream tracking, while still storing `branch.<name>.guardexBase`.
+- Mirror the same no-upstream rule in the `scripts/codex-agent.sh` fallback starter so legacy or recovery paths cannot reintroduce the bug.
+- Lock the behavior with focused install regressions and document that fresh sandbox branches are intentionally unpublished until the first push.
+
+## Impact
+
+- Affects branch/worktree bootstrap only; publish behavior remains unchanged because the first `git push -u` still establishes the real upstream branch.
+- Low rollout risk because `agent-branch-finish` already reads `guardexBase` metadata instead of relying on branch upstream config.
+- Owned scope for this change: branch-start bootstrap, codex-agent fallback bootstrap, install regressions, and README startup guidance.

--- a/openspec/changes/agent-codex-clear-agent-upstream-on-branch-start-2026-04-20-20-06/specs/agent-branch-upstream-tracking/spec.md
+++ b/openspec/changes/agent-codex-clear-agent-upstream-on-branch-start-2026-04-20-20-06/specs/agent-branch-upstream-tracking/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: agent-branch-upstream-tracking behavior
+The system SHALL keep freshly created `agent/*` worktree branches unpublished until the branch is explicitly pushed, while still remembering which protected base branch they were started from.
+
+#### Scenario: Branch start from a protected base branch
+- **GIVEN** `scripts/agent-branch-start.sh` creates a new `agent/*` branch from `origin/main`, `origin/dev`, or another protected base branch
+- **WHEN** the new sandbox worktree is ready
+- **THEN** the new `agent/*` branch has no git upstream configured
+- **AND** `branch.<agent-branch>.guardexBase` still stores the protected base branch name
+- **AND** future publish steps can establish the upstream branch explicitly with `git push -u`.
+
+#### Scenario: Codex fallback sandbox start
+- **GIVEN** `scripts/codex-agent.sh` falls back to its internal safe worktree starter
+- **WHEN** it creates a new `agent/*` branch from a protected base branch
+- **THEN** the fallback-created branch has no git upstream configured
+- **AND** the fallback path still stores `branch.<agent-branch>.guardexBase`.

--- a/openspec/changes/agent-codex-clear-agent-upstream-on-branch-start-2026-04-20-20-06/tasks.md
+++ b/openspec/changes/agent-codex-clear-agent-upstream-on-branch-start-2026-04-20-20-06/tasks.md
@@ -1,0 +1,21 @@
+## 1. Specification
+
+- [x] 1.1 Finalize proposal scope and acceptance criteria for `agent-codex-clear-agent-upstream-on-branch-start-2026-04-20-20-06`.
+- [x] 1.2 Define normative requirements in `specs/agent-branch-upstream-tracking/spec.md`.
+
+## 2. Implementation
+
+- [x] 2.1 Implement scoped behavior changes.
+- [x] 2.2 Add/update focused regression coverage.
+
+## 3. Verification
+
+- [x] 3.1 Run targeted project verification commands.
+- [x] 3.2 Run `openspec validate agent-codex-clear-agent-upstream-on-branch-start-2026-04-20-20-06 --type change --strict`.
+- [x] 3.3 Run `openspec validate --specs`.
+
+## 4. Completion
+
+- [ ] 4.1 Finish the agent branch via PR merge + cleanup (`gx finish --via-pr --wait-for-merge --cleanup` or `bash scripts/agent-branch-finish.sh --branch <agent-branch> --base <base-branch> --via-pr --wait-for-merge --cleanup`).
+- [ ] 4.2 Record PR URL + final `MERGED` state in the completion handoff.
+- [ ] 4.3 Confirm sandbox cleanup (`git worktree list`, `git branch -a`) or capture a `BLOCKED:` handoff if merge/cleanup is pending.

--- a/scripts/agent-branch-start.sh
+++ b/scripts/agent-branch-start.sh
@@ -474,12 +474,14 @@ if [[ -n "$current_branch" && "$current_branch" != "HEAD" ]] && is_protected_bra
   fi
 fi
 
-git -C "$repo_root" worktree add -b "$branch_name" "$worktree_path" "$start_ref"
-git -C "$repo_root" config "branch.${branch_name}.guardexBase" "$BASE_BRANCH" >/dev/null 2>&1 || true
-
-if git -C "$repo_root" show-ref --verify --quiet "refs/remotes/origin/${BASE_BRANCH}"; then
-  git -C "$worktree_path" branch --set-upstream-to="origin/${BASE_BRANCH}" "$branch_name" >/dev/null 2>&1 || true
+worktree_add_output=""
+if ! worktree_add_output="$(git -C "$repo_root" worktree add -b "$branch_name" "$worktree_path" "$start_ref" 2>&1)"; then
+  printf '%s\n' "$worktree_add_output" >&2
+  exit 1
 fi
+git -C "$repo_root" config "branch.${branch_name}.guardexBase" "$BASE_BRANCH" >/dev/null 2>&1 || true
+# Fresh agent branches should start unpublished; clear any inherited base-branch tracking.
+git -C "$worktree_path" branch --unset-upstream "$branch_name" >/dev/null 2>&1 || true
 
 if [[ -n "$auto_transfer_stash_ref" ]]; then
   if git -C "$worktree_path" stash apply "$auto_transfer_stash_ref" >/dev/null 2>&1; then

--- a/scripts/codex-agent.sh
+++ b/scripts/codex-agent.sh
@@ -274,11 +274,13 @@ start_sandbox_fallback() {
     return 1
   fi
 
-  git -C "$repo_root" worktree add -b "$branch_name" "$worktree_path" "$start_ref" >/dev/null
-  git -C "$repo_root" config "branch.${branch_name}.guardexBase" "$base_branch" >/dev/null 2>&1 || true
-  if git -C "$repo_root" show-ref --verify --quiet "refs/remotes/origin/${base_branch}"; then
-    git -C "$worktree_path" branch --set-upstream-to="origin/${base_branch}" "$branch_name" >/dev/null 2>&1 || true
+  local worktree_add_output=""
+  if ! worktree_add_output="$(git -C "$repo_root" worktree add -b "$branch_name" "$worktree_path" "$start_ref" 2>&1)"; then
+    printf '%s\n' "$worktree_add_output" >&2
+    return 1
   fi
+  git -C "$repo_root" config "branch.${branch_name}.guardexBase" "$base_branch" >/dev/null 2>&1 || true
+  git -C "$worktree_path" branch --unset-upstream "$branch_name" >/dev/null 2>&1 || true
 
   printf '[agent-branch-start] Created branch: %s\n' "$branch_name"
   printf '[agent-branch-start] Worktree: %s\n' "$worktree_path"

--- a/templates/scripts/agent-branch-start.sh
+++ b/templates/scripts/agent-branch-start.sh
@@ -474,12 +474,14 @@ if [[ -n "$current_branch" && "$current_branch" != "HEAD" ]] && is_protected_bra
   fi
 fi
 
-git -C "$repo_root" worktree add -b "$branch_name" "$worktree_path" "$start_ref"
-git -C "$repo_root" config "branch.${branch_name}.guardexBase" "$BASE_BRANCH" >/dev/null 2>&1 || true
-
-if git -C "$repo_root" show-ref --verify --quiet "refs/remotes/origin/${BASE_BRANCH}"; then
-  git -C "$worktree_path" branch --set-upstream-to="origin/${BASE_BRANCH}" "$branch_name" >/dev/null 2>&1 || true
+worktree_add_output=""
+if ! worktree_add_output="$(git -C "$repo_root" worktree add -b "$branch_name" "$worktree_path" "$start_ref" 2>&1)"; then
+  printf '%s\n' "$worktree_add_output" >&2
+  exit 1
 fi
+git -C "$repo_root" config "branch.${branch_name}.guardexBase" "$BASE_BRANCH" >/dev/null 2>&1 || true
+# Fresh agent branches should start unpublished; clear any inherited base-branch tracking.
+git -C "$worktree_path" branch --unset-upstream "$branch_name" >/dev/null 2>&1 || true
 
 if [[ -n "$auto_transfer_stash_ref" ]]; then
   if git -C "$worktree_path" stash apply "$auto_transfer_stash_ref" >/dev/null 2>&1; then

--- a/templates/scripts/codex-agent.sh
+++ b/templates/scripts/codex-agent.sh
@@ -274,11 +274,13 @@ start_sandbox_fallback() {
     return 1
   fi
 
-  git -C "$repo_root" worktree add -b "$branch_name" "$worktree_path" "$start_ref" >/dev/null
-  git -C "$repo_root" config "branch.${branch_name}.guardexBase" "$base_branch" >/dev/null 2>&1 || true
-  if git -C "$repo_root" show-ref --verify --quiet "refs/remotes/origin/${base_branch}"; then
-    git -C "$worktree_path" branch --set-upstream-to="origin/${base_branch}" "$branch_name" >/dev/null 2>&1 || true
+  local worktree_add_output=""
+  if ! worktree_add_output="$(git -C "$repo_root" worktree add -b "$branch_name" "$worktree_path" "$start_ref" 2>&1)"; then
+    printf '%s\n' "$worktree_add_output" >&2
+    return 1
   fi
+  git -C "$repo_root" config "branch.${branch_name}.guardexBase" "$base_branch" >/dev/null 2>&1 || true
+  git -C "$worktree_path" branch --unset-upstream "$branch_name" >/dev/null 2>&1 || true
 
   printf '[agent-branch-start] Created branch: %s\n' "$branch_name"
   printf '[agent-branch-start] Worktree: %s\n' "$worktree_path"

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -1398,7 +1398,7 @@ test('setup agent-branch-start supports optional OpenSpec auto-bootstrap toggles
   );
 });
 
-test('setup agent-branch-start defaults base to current branch and stores per-branch base metadata', () => {
+test('setup agent-branch-start defaults base to current branch, stores base metadata, and leaves the agent branch unpublished', () => {
   const repoDir = initRepoOnBranch('main');
   seedCommit(repoDir);
   attachOriginRemoteForBranch(repoDir, 'main');
@@ -1417,12 +1417,18 @@ test('setup agent-branch-start defaults base to current branch and stores per-br
 
   result = runCmd('bash', ['scripts/agent-branch-start.sh', 'auto-base', 'bot'], repoDir);
   assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /set up to track/i);
   const agentBranch = extractCreatedBranch(result.stdout);
   const agentWorktree = extractCreatedWorktree(result.stdout);
 
   const upstream = runCmd('git', ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'], agentWorktree);
-  assert.equal(upstream.status, 0, upstream.stderr || upstream.stdout);
-  assert.equal(upstream.stdout.trim(), 'origin/main');
+  assert.notEqual(upstream.status, 0, upstream.stderr || upstream.stdout);
+
+  const upstreamRemote = runCmd('git', ['config', '--get', `branch.${agentBranch}.remote`], repoDir);
+  assert.notEqual(upstreamRemote.status, 0, upstreamRemote.stderr || upstreamRemote.stdout);
+
+  const upstreamMerge = runCmd('git', ['config', '--get', `branch.${agentBranch}.merge`], repoDir);
+  assert.notEqual(upstreamMerge.status, 0, upstreamMerge.stderr || upstreamMerge.stdout);
 
   const storedBase = runCmd('git', ['config', '--get', `branch.${agentBranch}.guardexBase`], repoDir);
   assert.equal(storedBase.status, 0, storedBase.stderr || storedBase.stdout);
@@ -2587,6 +2593,7 @@ test('codex-agent launches codex inside a fresh sandbox worktree and keeps branc
 test('codex-agent restores local branch and falls back to safe worktree start when starter script switches in-place', () => {
   const repoDir = initRepo();
   seedCommit(repoDir);
+  attachOriginRemote(repoDir);
 
   const setupResult = runNode(['setup', '--target', repoDir, '--no-global-install'], repoDir);
   assert.equal(setupResult.status, 0, setupResult.stderr || setupResult.stdout);
@@ -2657,6 +2664,13 @@ test('codex-agent restores local branch and falls back to safe worktree start wh
     true,
     'fallback sandbox path should still scaffold OpenSpec change proposal',
   );
+
+  const fallbackUpstream = runCmd('git', ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'], launchedCwd);
+  assert.notEqual(fallbackUpstream.status, 0, fallbackUpstream.stderr || fallbackUpstream.stdout);
+
+  const fallbackBase = runCmd('git', ['config', '--get', `branch.${launchedBranch}.guardexBase`], repoDir);
+  assert.equal(fallbackBase.status, 0, fallbackBase.stderr || fallbackBase.stdout);
+  assert.equal(fallbackBase.stdout.trim(), 'dev');
 
   const currentBranch = runCmd('git', ['branch', '--show-current'], repoDir);
   assert.equal(currentBranch.status, 0, currentBranch.stderr || currentBranch.stdout);


### PR DESCRIPTION
Automated by scripts/agent-branch-finish.sh (PR flow).