### PR TITLE
Document the current companion tool stack and wire cavemem into setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ flowchart LR
 - **Explicit file lock claiming** — an agent declares which files it's editing before it edits them.
 - **Deletion guard** — claimed files can't be removed by another agent.
 - **Protected-base safety** — `main`, `dev`, `master` are blocked by default; agents must go through PRs.
-- **Auto-merges agent configs into every worktree** — `oh-my-codex`, `oh-my-claude`, caveman mode, and OpenSpec all get applied automatically so every spawned agent starts tuned, not bare.
+- **Auto-merges agent configs into every worktree** — `oh-my-codex`, `oh-my-claudecode`, caveman mode, and OpenSpec all get applied automatically so every spawned agent starts tuned, not bare.
 - **Repair/doctor flow** — when drift happens (and it will), `gx doctor` gets you back to a clean state.
 - **Auto-finish** — when Codex exits a session, Guardex commits sandbox changes, syncs against the base, retries once if the base moved, and opens a PR.
 
@@ -235,7 +235,7 @@ A few things worth knowing up front:
 
 - Running `gx` with no command opens the status/health view.
 - `gx init` is just an alias for `gx setup`.
-- Setup/doctor can install missing global OMX, OpenSpec, and codex-auth — but only with explicit Y/N confirmation.
+- Setup/doctor can install missing global companion CLIs (OMC runtime, OpenSpec, cavemem, codex-auth) — but only with explicit Y/N confirmation.
 - Direct commits/pushes to protected branches are **blocked** by default. Agents must use the `agent/*` + PR flow.
 - **Exception:** VS Code Source Control commits are allowed on protected branches that exist only locally (no upstream, no remote branch).
 - On protected `main`, `gx doctor` auto-runs in a sandbox agent branch/worktree so it can't touch your real main.
@@ -253,12 +253,13 @@ git config multiagent.allowVscodeProtectedBranchWrites true
 
 ## Companion tools
 
-GitGuardex is designed to work alongside these. All optional — but if you're running many agents, you probably want them. `gx status` reports each one's state:
+GitGuardex is designed to work alongside these. All optional — but if you're running many agents, you probably want them. `gx status` reports the machine-detectable global helpers; plugin/skills-first add-ons like `caveman` and `cavekit` are documented below for manual setup.
 
 ```text
 ● oh-my-codex: active
-● oh-my-claude: active
+● oh-my-claude-sisyphus: active
 ● @fission-ai/openspec: active
+● cavemem: active
 ● @imdeadpool/codex-account-switcher: active
 ● gh: active
 ```
@@ -273,13 +274,47 @@ npm i -g oh-my-codex
 
 Repo: <https://github.com/Yeachan-Heo/oh-my-codex>
 
-### oh-my-claude — Claude Code equivalent
+### oh-my-claudecode — Claude Code equivalent
 
-Claude-side mirror of oh-my-codex. Same idea: skills, commands, and defaults loaded into every Claude Code session. Guardex merges it into worktrees alongside oh-my-codex so mixed Codex + Claude agent fleets behave consistently.
+Claude-side mirror of oh-my-codex. Same idea: skills, commands, and defaults loaded into every Claude Code session. Guardex merges it into worktrees alongside oh-my-codex so mixed Codex + Claude agent fleets behave consistently. For the npm CLI/runtime path, the published package name is `oh-my-claude-sisyphus`.
 
 ```sh
-npm i -g oh-my-claude
+npm i -g oh-my-claude-sisyphus@latest
 ```
+
+Repo: <https://github.com/Yeachan-Heo/oh-my-claudecode>
+
+### Caveman — output compression for long agent runs
+
+Ultra-compressed response mode for Claude/Codex-style agents. Useful when you want less output-token churn during long reviews, debug loops, or multi-agent sessions.
+
+```sh
+npx skills add JuliusBrussee/caveman
+```
+
+Repo: <https://github.com/JuliusBrussee/caveman>
+
+### Cavemem — local persistent memory for agents
+
+Cross-agent memory with local SQLite + MCP. Helpful when you want Codex or Claude sessions to retain compressed history across runs. `gx setup` can install the CLI; you still run the IDE wiring once per machine.
+
+```sh
+npm install -g cavemem
+cavemem install --ide codex
+cavemem status
+```
+
+Repo: <https://github.com/JuliusBrussee/cavemem>
+
+### Cavekit — spec-driven build loop
+
+Spec-driven workflow layer for building from durable specs with explicit build/check commands. The current install path also brings in its `spec`, `build`, `check`, `caveman`, and `backprop` skills.
+
+```sh
+npx skills add JuliusBrussee/cavekit
+```
+
+Repo: <https://github.com/JuliusBrussee/cavekit>
 
 ### OpenSpec — spec-driven workflows
 

--- a/bin/multiagent-safety.js
+++ b/bin/multiagent-safety.js
@@ -11,10 +11,13 @@ const TOOL_NAME = 'gitguardex';
 const SHORT_TOOL_NAME = 'gx';
 const LEGACY_NAMES = ['guardex', 'multiagent-safety'];
 const OPENSPEC_PACKAGE = '@fission-ai/openspec';
+const OMC_PACKAGE = 'oh-my-claude-sisyphus';
+const CAVEMEM_PACKAGE = 'cavemem';
 const GLOBAL_TOOLCHAIN_PACKAGES = [
   'oh-my-codex',
-  'oh-my-claude',
+  OMC_PACKAGE,
   OPENSPEC_PACKAGE,
+  CAVEMEM_PACKAGE,
   '@imdeadpool/codex-account-switcher',
 ];
 const GH_BIN = process.env.GUARDEX_GH_BIN || 'gh';
@@ -4713,7 +4716,7 @@ function setup(rawArgs) {
       `[${TOOL_NAME}] ✅ Global tools installed (${(globalInstallStatus.packages || []).join(', ')}).`,
     );
   } else if (globalInstallStatus.status === 'already-installed') {
-    console.log(`[${TOOL_NAME}] ✅ OMX/OpenSpec/codex-auth npm global tools already installed. Skipping.`);
+    console.log(`[${TOOL_NAME}] ✅ Companion npm global tools already installed. Skipping.`);
   } else if (globalInstallStatus.status === 'failed') {
     console.log(
       `[${TOOL_NAME}] ⚠️ Global install failed: ${globalInstallStatus.reason}\n` +

--- a/docs/images/workflow-gx-terminal-status.svg
+++ b/docs/images/workflow-gx-terminal-status.svg
@@ -1,9 +1,9 @@
-<svg width="1600" height="1180" viewBox="0 0 1600 1180" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+<svg width="1600" height="1224" viewBox="0 0 1600 1224" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">GitGuardex terminal status output</title>
   <desc id="desc">A terminal screenshot style illustration showing the gx status help screen with active services, repo path, branch, commands, and doctor hint.</desc>
 
-  <rect width="1600" height="1180" fill="#101725"/>
-  <rect x="18" y="18" width="1564" height="1144" rx="16" fill="#05070C" stroke="#1E293B"/>
+  <rect width="1600" height="1224" fill="#101725"/>
+  <rect x="18" y="18" width="1564" height="1188" rx="16" fill="#05070C" stroke="#1E293B"/>
   <rect x="18" y="18" width="1564" height="42" rx="16" fill="#111827"/>
   <circle cx="52" cy="39" r="7" fill="#EF4444"/>
   <circle cx="76" cy="39" r="7" fill="#F59E0B"/>
@@ -19,26 +19,27 @@
     <text x="28" y="142">[gitguardex] CLI: @imdeadpool/guardex/7.0.10 linux-x64 node-v22.22.0</text>
     <text x="28" y="186">[gitguardex] Global services:</text>
     <text x="64" y="230">- ● oh-my-codex: active</text>
-    <text x="64" y="274">- ● oh-my-claude: active</text>
+    <text x="64" y="274">- ● oh-my-claude-sisyphus: active</text>
     <text x="64" y="318">- ● @fission-ai/openspec: active</text>
-    <text x="64" y="362">- ● @imdeadpool/codex-account-switcher: active</text>
-    <text x="64" y="406">- ● GitHub (gh): active</text>
-    <text x="28" y="450">[gitguardex] Repo safety service: ● active.</text>
-    <text x="28" y="494">[gitguardex] Repo: /home/deadpool/Documents/recodee</text>
-    <text x="28" y="538">[gitguardex] Branch: dev</text>
-    <text x="28" y="582" fill="#22D3EE">gitguardex-tools logs:</text>
+    <text x="64" y="362">- ● cavemem: active</text>
+    <text x="64" y="406">- ● @imdeadpool/codex-account-switcher: active</text>
+    <text x="64" y="450">- ● GitHub (gh): active</text>
+    <text x="28" y="494">[gitguardex] Repo safety service: ● active.</text>
+    <text x="28" y="538">[gitguardex] Repo: /home/deadpool/Documents/recodee</text>
+    <text x="28" y="582">[gitguardex] Branch: dev</text>
+    <text x="28" y="626" fill="#22D3EE">gitguardex-tools logs:</text>
 
-    <text x="52" y="640">└─ USAGE</text>
-    <text x="84" y="684">$ gx &lt;command&gt; [options]</text>
-    <text x="52" y="736">└─ COMMANDS</text>
-    <text x="84" y="780">status   Show GitGuardex CLI + service health without modifying files</text>
-    <text x="84" y="824">setup    Install, repair, and verify guardrails (flags: --repair, --install-only, --target)</text>
-    <text x="84" y="868">doctor   Repair drift + verify (auto-sandboxes on protected main)</text>
-    <text x="84" y="912">protect  Manage protected branches (list/add/remove/set/reset)</text>
-    <text x="84" y="956">sync     Sync agent branches with origin/&lt;base&gt;</text>
-    <text x="84" y="1000">finish   Commit + PR + merge completed agent branches (--all, --branch)</text>
-    <text x="84" y="1044">cleanup  Prune merged/stale agent branches and worktrees</text>
-    <text x="84" y="1088">prompt   Print AI setup checklist (--exec, --snippet)</text>
-    <text x="84" y="1132">Try 'gitguardex doctor' for one-step repair + verification.</text>
+    <text x="52" y="684">└─ USAGE</text>
+    <text x="84" y="728">$ gx &lt;command&gt; [options]</text>
+    <text x="52" y="780">└─ COMMANDS</text>
+    <text x="84" y="824">status   Show GitGuardex CLI + service health without modifying files</text>
+    <text x="84" y="868">setup    Install, repair, and verify guardrails (flags: --repair, --install-only, --target)</text>
+    <text x="84" y="912">doctor   Repair drift + verify (auto-sandboxes on protected main)</text>
+    <text x="84" y="956">protect  Manage protected branches (list/add/remove/set/reset)</text>
+    <text x="84" y="1000">sync     Sync agent branches with origin/&lt;base&gt;</text>
+    <text x="84" y="1044">finish   Commit + PR + merge completed agent branches (--all, --branch)</text>
+    <text x="84" y="1088">cleanup  Prune merged/stale agent branches and worktrees</text>
+    <text x="84" y="1132">prompt   Print AI setup checklist (--exec, --snippet)</text>
+    <text x="84" y="1176">Try 'gitguardex doctor' for one-step repair + verification.</text>
   </g>
 </svg>

--- a/openspec/changes/agent-codex-add-caveman-stack-and-claudecode-links-2026-04-21-03-02/notes.md
+++ b/openspec/changes/agent-codex-add-caveman-stack-and-claudecode-links-2026-04-21-03-02/notes.md
@@ -1,0 +1,5 @@
+# T1 Notes
+
+- Add official companion-tool links for `oh-my-claudecode`, `caveman`, `cavemem`, and `cavekit` to the README.
+- Align the Claude-side npm runtime reference with the official package name `oh-my-claude-sisyphus`.
+- Extend `gx`'s npm-global companion toolchain to include `cavemem`, and update the status screenshot/tests to match.

--- a/openspec/changes/agent-codex-add-caveman-stack-and-claudecode-links-2026-04-21-03-02/specs/companion-tooling/spec.md
+++ b/openspec/changes/agent-codex-add-caveman-stack-and-claudecode-links-2026-04-21-03-02/specs/companion-tooling/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: `gx status` reflects the current companion npm toolchain
+
+The `gx status` and `gx setup` npm-global companion-tool path SHALL track the current machine-detectable companion CLI set: `oh-my-codex`, `oh-my-claude-sisyphus`, `@fission-ai/openspec`, `cavemem`, and `@imdeadpool/codex-account-switcher`.
+
+#### Scenario: `cavemem` is installed globally
+
+- **GIVEN** `npm ls -g --json` includes `cavemem`
+- **WHEN** the user runs `gx status` or `gx status --json`
+- **THEN** the reported services include `cavemem`
+- **AND** its state is `active`
+
+#### Scenario: setup installs missing companion npm tools
+
+- **GIVEN** `oh-my-codex` is already present globally
+- **AND** one or more of `oh-my-claude-sisyphus`, `@fission-ai/openspec`, `cavemem`, or `@imdeadpool/codex-account-switcher` are missing
+- **WHEN** the user runs `gx setup` and approves the optional global install prompt
+- **THEN** Guardex installs only the missing companion npm tools
+
+### Requirement: README companion docs use current official tool names
+
+The README companion-tools section SHALL use the current official repo/install names for the Claude-side orchestration project and SHALL document the Caveman ecosystem add-ons (`caveman`, `cavemem`, `cavekit`) with their official companion-tool guidance.
+
+#### Scenario: reader checks the companion tools section
+
+- **GIVEN** a reader opens the README companion-tools section
+- **WHEN** they inspect the Claude and Caveman ecosystem entries
+- **THEN** they see `oh-my-claudecode` as the repo/project name
+- **AND** they see `oh-my-claude-sisyphus` as the npm runtime package name
+- **AND** they see companion entries for `caveman`, `cavemem`, and `cavekit`

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -2168,6 +2168,8 @@ test('status --json returns cli, services, and repo summary', () => {
   assert.equal(parsed.cli.name, '@imdeadpool/guardex');
   assert.equal(typeof parsed.cli.version, 'string');
   assert.equal(Array.isArray(parsed.services), true);
+  assert.ok(parsed.services.some((service) => service.name === 'oh-my-claude-sisyphus'));
+  assert.ok(parsed.services.some((service) => service.name === 'cavemem'));
   assert.equal(parsed.repo.inGitRepo, true);
   assert.equal(typeof parsed.repo.serviceStatus, 'string');
   assert.equal(parsed.repo.scan.repoRoot, repoDir);
@@ -3830,13 +3832,13 @@ test('setup dry-run accepts explicit global install approval flags', () => {
   assert.match(result.stdout, /Dry run setup done/);
 });
 
-test('setup skips global install when OMX/OpenSpec/codex-auth are already installed', () => {
+test('setup skips global install when companion npm tools are already installed', () => {
   const repoDir = initRepo();
   const marker = path.join(repoDir, '.global-install-called');
   const fakeNpm = createFakeNpmScript(`
 if [[ "$1" == "list" ]]; then
   cat <<'JSON'
-{"dependencies":{"oh-my-codex":{"version":"1.0.0"},"@fission-ai/openspec":{"version":"1.0.0"},"@imdeadpool/codex-account-switcher":{"version":"1.0.0"}}}
+{"dependencies":{"oh-my-codex":{"version":"1.0.0"},"oh-my-claude-sisyphus":{"version":"1.0.0"},"@fission-ai/openspec":{"version":"1.0.0"},"cavemem":{"version":"1.0.0"},"@imdeadpool/codex-account-switcher":{"version":"1.0.0"}}}
 JSON
   exit 0
 fi
@@ -3883,7 +3885,7 @@ exit 1
   assert.equal(result.status, 0, result.stderr || result.stdout);
   assert.equal(fs.existsSync(marker), true, 'global install should run for missing package');
   const args = fs.readFileSync(marker, 'utf8').trim();
-  assert.equal(args, 'i -g @fission-ai/openspec @imdeadpool/codex-account-switcher');
+  assert.equal(args, 'i -g oh-my-claude-sisyphus @fission-ai/openspec cavemem @imdeadpool/codex-account-switcher');
 });
 
 test('status reports gh dependency as inactive when gh is unavailable', () => {
@@ -3904,7 +3906,7 @@ test('setup warns when gh dependency is missing', () => {
   const fakeNpm = createFakeNpmScript(`
 if [[ "$1" == "list" ]]; then
   cat <<'JSON'
-{"dependencies":{"oh-my-codex":{"version":"1.0.0"},"@fission-ai/openspec":{"version":"1.0.0"},"@imdeadpool/codex-account-switcher":{"version":"1.0.0"}}}
+{"dependencies":{"oh-my-codex":{"version":"1.0.0"},"oh-my-claude-sisyphus":{"version":"1.0.0"},"@fission-ai/openspec":{"version":"1.0.0"},"cavemem":{"version":"1.0.0"},"@imdeadpool/codex-account-switcher":{"version":"1.0.0"}}}
 JSON
   exit 0
 fi


### PR DESCRIPTION
The companion tools section now points at the official oh-my-claudecode repo, uses the published npm runtime name oh-my-claude-sisyphus, and documents the Caveman ecosystem add-ons with current install guidance. The CLI's companion npm toolchain also picks up cavemem so setup/status match the documented machine-detectable stack.

Constraint: oh-my-claudecode's npm runtime is published as oh-my-claude-sisyphus, while caveman and cavekit remain plugin/skills-first installs rather than plain npm globals
Rejected: Auto-install caveman and cavekit from gx setup | their official install paths are plugin/skills-first and Guardex's companion probe is npm-global only today
Confidence: high
Scope-risk: narrow
Directive: Keep README companion entries and GLOBAL_TOOLCHAIN_PACKAGES aligned with official upstream install surfaces before changing gx status output again
Tested: git diff --check; node --check bin/multiagent-safety.js; openspec validate agent-codex-add-caveman-stack-and-claudecode-links-2026-04-21-03-02 --type change --strict; openspec validate --specs; npm test
Not-tested: Live npm global install flow; remote push/PR path