### PR TITLE
Publish a fresh Guardex version after npm rejected 7.0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,10 @@ npm pack --dry-run
 <details>
 <summary><strong>v7.x</strong></summary>
 
+### v7.0.14
+- Bumped `@imdeadpool/guardex` from `7.0.13` → `7.0.14` after npm rejected a republish over the already-published `7.0.13`.
+- No package payload changes beyond the release metadata bump; this release exists so `npm publish` can proceed with a fresh semver.
+
 ### v7.0.13
 - `gx status` and `gx setup` now present the Claude companion as `oh-my-claudecode` while still installing the published npm package `oh-my-claude-sisyphus`.
 - When that dependency is inactive or the user declines the optional install, Guardex now prints the upstream repo URL so the missing dependency is explicit instead of hidden behind the npm package name.

--- a/openspec/changes/agent-codex-bump-guardex-to-7-0-14-2026-04-21-11-17/.openspec.yaml
+++ b/openspec/changes/agent-codex-bump-guardex-to-7-0-14-2026-04-21-11-17/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/agent-codex-bump-guardex-to-7-0-14-2026-04-21-11-17/notes.md
+++ b/openspec/changes/agent-codex-bump-guardex-to-7-0-14-2026-04-21-11-17/notes.md
@@ -1,0 +1,5 @@
+# T1 Notes
+
+- Bump `@imdeadpool/guardex` from `7.0.13` to `7.0.14` so npm can accept the next publish after rejecting a republish over `7.0.13`.
+- Update the README release notes in the same change to keep the publish/version history aligned with the package metadata.
+- Keep the release narrowly scoped to metadata only; no package payload changes are intended in this bump.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "7.0.13",
+  "version": "7.0.14",
   "description": "GitGuardex: hardened multi-agent git guardrails for parallel agent work.",
   "license": "MIT",
   "preferGlobal": true,


### PR DESCRIPTION
Automated by scripts/agent-branch-finish.sh (PR flow).