### PR TITLE
Unblock the next Guardex npm publish after 7.0.14 was already taken

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,11 @@ npm pack --dry-run
 <details>
 <summary><strong>v7.x</strong></summary>
 
+### v7.0.15
+- `gx doctor` no longer blocks recursive nested protected-repo repairs on child PR merge waits; nested sandboxes now force `--no-wait-for-merge` so the parent repair loop can continue.
+- `gx setup` can now refresh managed files from protected `main` through a temporary sandbox branch/worktree, sync the managed outputs back to the visible base checkout, and prune the sandbox afterward.
+- Bumped `@imdeadpool/guardex` from `7.0.14` → `7.0.15` after npm rejected a republish over the already-published `7.0.14`.
+
 ### v7.0.14
 - Bumped `@imdeadpool/guardex` from `7.0.13` → `7.0.14` after npm rejected a republish over the already-published `7.0.13`.
 - No package payload changes beyond the release metadata bump; this release exists so `npm publish` can proceed with a fresh semver.

--- a/openspec/changes/agent-codex-release-guardex-7-0-15-2026-04-21-12-16/.openspec.yaml
+++ b/openspec/changes/agent-codex-release-guardex-7-0-15-2026-04-21-12-16/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/agent-codex-release-guardex-7-0-15-2026-04-21-12-16/proposal.md
+++ b/openspec/changes/agent-codex-release-guardex-7-0-15-2026-04-21-12-16/proposal.md
@@ -1,0 +1,14 @@
+## Why
+
+- `npm publish` rejected `@imdeadpool/guardex@7.0.14` because that version is already published, so the package needs the next publishable patch version before release can proceed.
+- The shipped behavior since `7.0.14` is not captured in the README release notes yet, and `package-lock.json` is also still lagging behind the manifest version.
+
+## What Changes
+
+- Bump the package release metadata from `7.0.14` to `7.0.15` in `package.json` and `package-lock.json`.
+- Add a `README.md` release-notes entry for `v7.0.15` that summarizes the post-`7.0.14` Guardex behavior now shipping in the package.
+
+## Impact
+
+- Unblocks the next npm publish without changing runtime behavior beyond what is already merged on `main`.
+- Keeps the packaged version, lockfile metadata, and documented release notes aligned so release state is easier to trust.

--- a/openspec/changes/agent-codex-release-guardex-7-0-15-2026-04-21-12-16/specs/release-version-bump/spec.md
+++ b/openspec/changes/agent-codex-release-guardex-7-0-15-2026-04-21-12-16/specs/release-version-bump/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Release recovery version alignment
+The release metadata SHALL move to the next publishable package version when npm rejects the current version as already published.
+
+#### Scenario: Recover from an already-published npm version
+- **GIVEN** `npm publish` rejects the current Guardex version as already published
+- **WHEN** maintainers prepare the recovery release
+- **THEN** `package.json` and `package-lock.json` SHALL be bumped to the next publishable semver
+- **AND** `README.md` SHALL record the new release version with the newly shipped behavior that the package now contains.

--- a/openspec/changes/agent-codex-release-guardex-7-0-15-2026-04-21-12-16/tasks.md
+++ b/openspec/changes/agent-codex-release-guardex-7-0-15-2026-04-21-12-16/tasks.md
@@ -1,0 +1,21 @@
+## 1. Specification
+
+- [x] 1.1 Finalize proposal scope and acceptance criteria for `agent-codex-release-guardex-7-0-15-2026-04-21-12-16`.
+- [x] 1.2 Define normative requirements in `specs/release-version-bump/spec.md`.
+
+## 2. Implementation
+
+- [x] 2.1 Bump `package.json`, `package-lock.json`, and `README.md` to the next publishable Guardex release version.
+- [x] 2.2 No new runtime regression coverage was added because this change only updates release metadata for already-merged behavior.
+
+## 3. Verification
+
+- [x] 3.1 Run `node --check bin/multiagent-safety.js`, `node --test test/metadata.test.js`, and `npm pack --dry-run` for the release-only change. The metadata suite still contains a pre-existing `Doctor/fix` expectation mismatch unrelated to this version bump.
+- [x] 3.2 Run `openspec validate agent-codex-release-guardex-7-0-15-2026-04-21-12-16 --type change --strict`.
+- [x] 3.3 Run `openspec validate --specs`.
+
+## 4. Completion
+
+- [ ] 4.1 Finish the agent branch via PR merge + cleanup (`gx finish --via-pr --wait-for-merge --cleanup` or `bash scripts/agent-branch-finish.sh --branch <agent-branch> --base <base-branch> --via-pr --wait-for-merge --cleanup`).
+- [ ] 4.2 Record PR URL + final `MERGED` state in the completion handoff.
+- [ ] 4.3 Confirm sandbox cleanup (`git worktree list`, `git branch -a`) or capture a `BLOCKED:` handoff if merge/cleanup is pending.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "7.0.13",
+  "version": "7.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@imdeadpool/guardex",
-      "version": "7.0.13",
+      "version": "7.0.15",
       "license": "MIT",
       "bin": {
         "gitguardex": "bin/multiagent-safety.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "7.0.14",
+  "version": "7.0.15",
   "description": "GitGuardex: hardened multi-agent git guardrails for parallel agent work.",
   "license": "MIT",
   "preferGlobal": true,


### PR DESCRIPTION
Automated by scripts/agent-branch-finish.sh (PR flow).