### PR TITLE
Keep doctor metadata guard aligned with repair-path refactors

### DIFF
--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -121,7 +121,7 @@ test('active doctor command remains single-source and runs the repair-first path
   const cliSource = fs.readFileSync(cliPath, 'utf8');
   const doctorDefs = cliSource.match(/function doctor\(rawArgs\)/g) || [];
   assert.equal(doctorDefs.length, 1, 'doctor() must not be duplicated');
-  assert.match(cliSource, /printOperations\('Doctor\/fix', fixPayload, singleRepoOptions\.dryRun\);/);
+  assert.match(cliSource, /printOperations\('Doctor\/fix', fixPayload,\s*[^)]+\.dryRun\);/);
 });
 
 test('worktree-change detection uses normal untracked-file mode', () => {


### PR DESCRIPTION
## Summary
- stop pinning the doctor repair-path metadata assertion to a specific local variable name
- keep the guard focused on the real contract: , , and a  option

## Verification
- node --test test/metadata.test.js
- node --test test/merge-workflow.test.js
- node --check bin/multiagent-safety.js