### PR TITLE
Keep release verification from losing its base ref on tag runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/openspec/changes/agent-codex-fix-release-workflow-base-ref-2026-04-22-23-34/.openspec.yaml
+++ b/openspec/changes/agent-codex-fix-release-workflow-base-ref-2026-04-22-23-34/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-22

--- a/openspec/changes/agent-codex-fix-release-workflow-base-ref-2026-04-22-23-34/notes.md
+++ b/openspec/changes/agent-codex-fix-release-workflow-base-ref-2026-04-22-23-34/notes.md
@@ -1,0 +1,28 @@
+# agent-codex-fix-release-workflow-base-ref-2026-04-22-23-34 (minimal / T1)
+
+Branch: `agent/codex/fix-release-workflow-base-ref-2026-04-22-23-34`
+
+The `v7.0.23` GitHub release exists, but the release workflow failed in `Verify` before npm publish because the tag checkout did not provide `origin/main` or `main` for the Active Agents base-version guard test. Fetch the full git history during the release workflow so the guard can resolve the base ref on release/tag runs, and lock that behavior with metadata coverage.
+
+Scope:
+- Update `.github/workflows/release.yml` checkout to fetch full history.
+- Add a metadata assertion that the release workflow keeps `fetch-depth: 0`.
+- Merge the fix, then rerun the release workflow manually on `main` so `@imdeadpool/guardex@7.0.23` can publish.
+
+Verification:
+- `node --test test/metadata.test.js --test-name-pattern "release workflow publishes with provenance in CI|release workflow only publishes from published releases or manual dispatch"`
+- `gh workflow run "Release to npm (provenance)" --repo recodeee/gitguardex --ref main`
+- `gh run list --repo recodeee/gitguardex --workflow "Release to npm (provenance)" --limit 3 --json databaseId,displayTitle,event,status,conclusion,url,headBranch`
+- `npm view @imdeadpool/guardex version dist-tags --json`
+
+## Handoff
+
+- Handoff: change=`agent-codex-fix-release-workflow-base-ref-2026-04-22-23-34`; branch=`agent/codex/fix-release-workflow-base-ref-2026-04-22-23-34`; scope=`.github/workflows/release.yml, test/metadata.test.js, openspec/changes/agent-codex-fix-release-workflow-base-ref-2026-04-22-23-34/*`; action=`merge workflow-only fix, manually rerun release workflow on main, and verify npm advances to 7.0.23`.
+- Copy prompt: Continue `agent-codex-fix-release-workflow-base-ref-2026-04-22-23-34` on branch `agent/codex/fix-release-workflow-base-ref-2026-04-22-23-34`. Work inside the existing sandbox, review `openspec/changes/agent-codex-fix-release-workflow-base-ref-2026-04-22-23-34/notes.md`, continue from the current state instead of creating a new sandbox, and when the work is done run `gx branch finish --branch agent/codex/fix-release-workflow-base-ref-2026-04-22-23-34 --base main --via-pr --wait-for-merge --cleanup`.
+
+## Cleanup
+
+- [ ] Run: `gx branch finish --branch agent/codex/fix-release-workflow-base-ref-2026-04-22-23-34 --base main --via-pr --wait-for-merge --cleanup`
+- [ ] Run: `gh workflow run "Release to npm (provenance)" --repo recodeee/gitguardex --ref main`
+- [ ] Record PR URL + `MERGED` state and rerun evidence in the completion handoff.
+- [ ] Confirm sandbox worktree is gone (`git worktree list`, `git branch -a`).

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -30,6 +30,7 @@ test('security and contribution docs exist', () => {
 test('release workflow publishes with provenance in CI', () => {
   const workflowPath = path.join(repoRoot, '.github', 'workflows', 'release.yml');
   const workflow = fs.readFileSync(workflowPath, 'utf8');
+  assert.match(workflow, /name:\s+Checkout\s+uses:\s+actions\/checkout@[0-9a-f]{40}[^\n]*\n\s+with:\s*\n\s+fetch-depth:\s+0/s);
   assert.match(workflow, /npm publish --provenance --access public/);
 });
 


### PR DESCRIPTION
Automated by gx branch finish (PR flow).