### PR TITLE
Detect parent gitlink drift even when submodules are ignored

### DIFF
--- a/openspec/changes/agent-codex-auto-commit-parent-subrepo-upgrades-2026-04-23-11-59/specs/finish/spec.md
+++ b/openspec/changes/agent-codex-auto-commit-parent-subrepo-upgrades-2026-04-23-11-59/specs/finish/spec.md
@@ -10,6 +10,7 @@ After a successful nested repository finish, Guardex SHALL detect when the finis
 - **WHEN** `gx branch finish` merges the nested agent branch and fast-forwards the nested base worktree
 - **THEN** Guardex commits the parent repo gitlink path with a message naming that subrepo pointer
 - **AND** unrelated parent staged paths are not included in that commit
+- **AND** parent `diff.ignoreSubmodules=all` settings do not hide the gitlink pointer update from this detection
 
 #### Scenario: Parent auto-commit is disabled
 

--- a/openspec/changes/agent-codex-auto-commit-parent-subrepo-upgrades-2026-04-23-11-59/tasks.md
+++ b/openspec/changes/agent-codex-auto-commit-parent-subrepo-upgrades-2026-04-23-11-59/tasks.md
@@ -12,6 +12,7 @@
 
 - [x] Add parent gitlink detection and path-scoped parent commit to `agent-branch-finish`.
 - [x] Pass parent gitlink controls through `gx finish`.
+- [x] Compare gitlink index SHA to nested HEAD so parent `diff.ignoreSubmodules=all` does not hide pointer upgrades.
 
 ## 4. Cleanup
 

--- a/scripts/agent-branch-finish.sh
+++ b/scripts/agent-branch-finish.sh
@@ -516,6 +516,9 @@ maybe_auto_commit_parent_gitlink() {
   local super_root=""
   local subrepo_rel=""
   local gitlink_mode=""
+  local gitlink_index_sha=""
+  local gitlink_parent_head_sha=""
+  local subrepo_head_sha=""
   local add_output=""
   local commit_output=""
   local commit_message=""
@@ -557,8 +560,10 @@ maybe_auto_commit_parent_gitlink() {
   if [[ "$gitlink_mode" != "160000" ]]; then
     return 0
   fi
-  if git -C "$super_root" diff --quiet -- "$subrepo_rel" \
-    && git -C "$super_root" diff --cached --quiet -- "$subrepo_rel"; then
+  gitlink_index_sha="$(git -C "$super_root" ls-files -s -- "$subrepo_rel" | awk 'NR == 1 { print $2 }')"
+  gitlink_parent_head_sha="$(git -C "$super_root" ls-tree HEAD -- "$subrepo_rel" | awk 'NR == 1 { print $3 }')"
+  subrepo_head_sha="$(git -C "$repo_common_root" rev-parse HEAD 2>/dev/null || true)"
+  if [[ -n "$gitlink_index_sha" && "$gitlink_index_sha" == "$gitlink_parent_head_sha" && "$gitlink_index_sha" == "$subrepo_head_sha" ]]; then
     return 0
   fi
 
@@ -568,7 +573,11 @@ maybe_auto_commit_parent_gitlink() {
     return 0
   fi
   if git -C "$super_root" diff --cached --quiet -- "$subrepo_rel"; then
-    return 0
+    gitlink_index_sha="$(git -C "$super_root" ls-files -s -- "$subrepo_rel" | awk 'NR == 1 { print $2 }')"
+    gitlink_parent_head_sha="$(git -C "$super_root" ls-tree HEAD -- "$subrepo_rel" | awk 'NR == 1 { print $3 }')"
+    if [[ "$gitlink_index_sha" == "$gitlink_parent_head_sha" ]]; then
+      return 0
+    fi
   fi
 
   commit_message="Update ${subrepo_rel} subrepo pointer"

--- a/templates/scripts/agent-branch-finish.sh
+++ b/templates/scripts/agent-branch-finish.sh
@@ -516,6 +516,9 @@ maybe_auto_commit_parent_gitlink() {
   local super_root=""
   local subrepo_rel=""
   local gitlink_mode=""
+  local gitlink_index_sha=""
+  local gitlink_parent_head_sha=""
+  local subrepo_head_sha=""
   local add_output=""
   local commit_output=""
   local commit_message=""
@@ -557,8 +560,10 @@ maybe_auto_commit_parent_gitlink() {
   if [[ "$gitlink_mode" != "160000" ]]; then
     return 0
   fi
-  if git -C "$super_root" diff --quiet -- "$subrepo_rel" \
-    && git -C "$super_root" diff --cached --quiet -- "$subrepo_rel"; then
+  gitlink_index_sha="$(git -C "$super_root" ls-files -s -- "$subrepo_rel" | awk 'NR == 1 { print $2 }')"
+  gitlink_parent_head_sha="$(git -C "$super_root" ls-tree HEAD -- "$subrepo_rel" | awk 'NR == 1 { print $3 }')"
+  subrepo_head_sha="$(git -C "$repo_common_root" rev-parse HEAD 2>/dev/null || true)"
+  if [[ -n "$gitlink_index_sha" && "$gitlink_index_sha" == "$gitlink_parent_head_sha" && "$gitlink_index_sha" == "$subrepo_head_sha" ]]; then
     return 0
   fi
 
@@ -568,7 +573,11 @@ maybe_auto_commit_parent_gitlink() {
     return 0
   fi
   if git -C "$super_root" diff --cached --quiet -- "$subrepo_rel"; then
-    return 0
+    gitlink_index_sha="$(git -C "$super_root" ls-files -s -- "$subrepo_rel" | awk 'NR == 1 { print $2 }')"
+    gitlink_parent_head_sha="$(git -C "$super_root" ls-tree HEAD -- "$subrepo_rel" | awk 'NR == 1 { print $3 }')"
+    if [[ "$gitlink_index_sha" == "$gitlink_parent_head_sha" ]]; then
+      return 0
+    fi
   fi
 
   commit_message="Update ${subrepo_rel} subrepo pointer"

--- a/test/finish.test.js
+++ b/test/finish.test.js
@@ -188,6 +188,8 @@ test('agent-branch-finish auto-commits parent gitlink after nested repo finish',
     ALLOW_COMMIT_ON_PROTECTED_BRANCH: '1',
   });
   assert.equal(result.status, 0, result.stderr || result.stdout);
+  result = runCmd('git', ['config', 'diff.ignoreSubmodules', 'all'], parentDir);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
   fs.writeFileSync(path.join(parentDir, 'unrelated-parent.txt'), 'already staged\n', 'utf8');
   result = runCmd('git', ['add', 'unrelated-parent.txt'], parentDir);
   assert.equal(result.status, 0, result.stderr || result.stdout);


### PR DESCRIPTION
Automated by gx branch finish (PR flow).