### PR TITLE
Cut a fresh publishable Guardex release after npm lagged

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,11 @@ npm pack --dry-run
 <details>
 <summary><strong>v7.x</strong></summary>
 
+### v7.0.26
+- Bumped `@imdeadpool/guardex` from `7.0.25` to `7.0.26` so npm can publish a fresh version after `v7.0.25` reached GitHub Releases while the registry stayed on `7.0.24`.
+- README now documents both `npx skills add recodeee/` and `npx skills add recodeee/gitguardex`, and explains why the picker shows `gitguardex` instead of a separate `guardex` skill.
+- Keep the release scoped to version metadata plus the already-merged README installer guidance on `main`; no additional CLI/runtime behavior changed in this lane.
+
 ### v7.0.25
 - Bumped `@imdeadpool/guardex` from `7.0.24` to `7.0.25` so npm and GitHub Releases can ship the current `main` payload.
 - The bundled `GitGuardex Active Agents` VS Code companion now self-heals stale repo-scan ignore settings in older repos, keeps plain managed sandboxes visible in Source Control, and preserves cleanup truth so the tree matches actual sandbox state.

--- a/openspec/changes/agent-codex-release-7-0-26-2026-04-23-16-21/notes.md
+++ b/openspec/changes/agent-codex-release-7-0-26-2026-04-23-16-21/notes.md
@@ -1,0 +1,16 @@
+# agent-codex-release-7-0-26-2026-04-23-16-21 (minimal / T1)
+
+Branch: `agent/codex/release-7-0-26-2026-04-23-16-21`
+
+Release-only lane: bump `@imdeadpool/guardex` to `7.0.26`, add the matching `README.md` release note entry, merge, and cut the GitHub release so publish automation can retry from a fresh semver after `v7.0.25` reached GitHub while npm still reported `7.0.24`.
+
+## Handoff
+
+- Handoff: change=`agent-codex-release-7-0-26-2026-04-23-16-21`; branch=`agent/codex/release-7-0-26-2026-04-23-16-21`; scope=`package.json, package-lock.json, README.md release notes`; action=`continue this sandbox, verify release-only metadata changes, then finish cleanup and cut GitHub release v7.0.26`.
+- Copy prompt: Continue `agent-codex-release-7-0-26-2026-04-23-16-21` on branch `agent/codex/release-7-0-26-2026-04-23-16-21`. Work inside the existing sandbox, review `openspec/changes/agent-codex-release-7-0-26-2026-04-23-16-21/notes.md`, continue from the current state instead of creating a new sandbox, and when the work is done run `gx branch finish --branch agent/codex/release-7-0-26-2026-04-23-16-21 --base main --via-pr --wait-for-merge --cleanup`.
+
+## Cleanup
+
+- [ ] Run: `gx branch finish --branch agent/codex/release-7-0-26-2026-04-23-16-21 --base main --via-pr --wait-for-merge --cleanup`
+- [ ] Record PR URL + `MERGED` state in the completion handoff.
+- [ ] Confirm sandbox worktree is gone (`git worktree list`, `git branch -a`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "7.0.25",
+  "version": "7.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@imdeadpool/guardex",
-      "version": "7.0.25",
+      "version": "7.0.26",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "7.0.25",
+  "version": "7.0.26",
   "description": "Guardian T-Rex for your multi-agent repo. Isolated worktrees, file locks, and PR-only merges stop parallel Codex & Claude agents from overwriting each other's work. Auto-wires Oh My Codex, Oh My Claude, OpenSpec, and Caveman.",
   "license": "MIT",
   "preferGlobal": true,


### PR DESCRIPTION
Automated by gx branch finish (PR flow).