### PR TITLE
Advance Guardex to v7.0.27 for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,12 @@ npm pack --dry-run
 <details>
 <summary><strong>v7.x</strong></summary>
 
+### v7.0.27
+- Bumped `@imdeadpool/guardex` from `7.0.26` to `7.0.27` so npm can publish a fresh version after `7.0.26` was already taken on the registry.
+- The shipped `agent-branch-start.sh` copies now keep the startup auto-transfer path alive under `set -o pipefail`, so Guardex can still restore moved changes back to the protected checkout when branch startup hits a later failure.
+- The shipped `agent-branch-finish.sh` copies now keep PR-only finish runs from opening temporary integration repos, so maintainers can finish directly through the existing PR lane without extra temp-repo churn.
+- Keep the release scoped to version metadata for the already-merged `main` payload; no additional runtime behavior changes are introduced in this release lane.
+
 ### v7.0.26
 - Bumped `@imdeadpool/guardex` from `7.0.25` to `7.0.26` so npm can publish a fresh version after `v7.0.25` reached GitHub Releases while the registry stayed on `7.0.24`.
 - README now documents both `npx skills add recodee/` and `npx skills add recodee/gitguardex`, clarifies that the global Guardex npm install does not auto-run the generic skills installer, and explains why the picker shows `gitguardex` instead of a separate `guardex` skill.

--- a/openspec/changes/agent-codex-release-guardex-7-0-27-2026-04-23/proposal.md
+++ b/openspec/changes/agent-codex-release-guardex-7-0-27-2026-04-23/proposal.md
@@ -1,0 +1,14 @@
+## Why
+
+- `@imdeadpool/guardex@7.0.26` is already published on npm, so the next publish attempt needs a fresh patch version.
+- `main` now includes the shipped `agent-branch-start.sh` pipefail recovery fix and the PR-only `agent-branch-finish.sh` temp-integration cleanup fix, but the release history does not yet document those operator-facing changes.
+
+## What Changes
+
+- Bump the package release metadata from `7.0.26` to `7.0.27` in `package.json` and `package-lock.json`.
+- Add a `README.md` release-notes entry for `v7.0.27` that documents the already-merged branch-start and branch-finish workflow fixes now included in the package payload.
+
+## Impact
+
+- Unblocks the next npm package publish and matching GitHub release without introducing new runtime behavior beyond what is already merged on `main`.
+- Keeps the package version and README release history aligned so operators can see which shipped workflow fixes landed in the publishable package.

--- a/openspec/changes/agent-codex-release-guardex-7-0-27-2026-04-23/specs/release-version-bump/spec.md
+++ b/openspec/changes/agent-codex-release-guardex-7-0-27-2026-04-23/specs/release-version-bump/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Release recovery version alignment
+The release metadata SHALL move to the next publishable package version when maintainers intentionally request the next npm release after the current published Guardex version.
+
+#### Scenario: Prepare the next publishable npm patch release
+- **GIVEN** the current Guardex package version is already the latest published release metadata in the repo and npm registry
+- **WHEN** maintainers request the next npm version bump
+- **THEN** `package.json` and `package-lock.json` SHALL be bumped to the next publishable semver
+- **AND** `README.md` SHALL record the new release version with the newly shipped behavior that the package now contains.

--- a/openspec/changes/agent-codex-release-guardex-7-0-27-2026-04-23/tasks.md
+++ b/openspec/changes/agent-codex-release-guardex-7-0-27-2026-04-23/tasks.md
@@ -1,0 +1,25 @@
+## Handoff
+
+- Handoff: change=`agent-codex-release-guardex-7-0-27-2026-04-23`; branch=`agent/codex/release-7-0-27-2026-04-23`; scope=`package.json`, `package-lock.json`, `README.md`; action=`bump Guardex to v7.0.27, document the shipped branch-start and PR-only finish fixes, and cut the next publishable release`.
+
+## 1. Specification
+
+- [x] 1.1 Finalize proposal scope and acceptance criteria for `agent-codex-release-guardex-7-0-27-2026-04-23`.
+- [x] 1.2 Define normative requirements in `specs/release-version-bump/spec.md`.
+
+## 2. Implementation
+
+- [x] 2.1 Bump `package.json`, `package-lock.json`, and `README.md` to the next publishable release version.
+- [x] 2.2 Keep the release scoped to metadata only; no new Guardex runtime behavior is introduced in this lane.
+
+## 3. Verification
+
+- [x] 3.1 Run `node --test test/metadata.test.js`, `node --check bin/multiagent-safety.js`, and `npm pack --dry-run` for the release-only change. All three passed in this lane; metadata finished with `23/23` passing tests, `node --check` exited clean, and `npm pack --dry-run` produced `imdeadpool-guardex-7.0.27.tgz`.
+- [x] 3.2 Run `openspec validate agent-codex-release-guardex-7-0-27-2026-04-23 --type change --strict`.
+- [x] 3.3 Run `openspec validate --specs`. Repo-level validation exited clean with `No items found to validate.`
+
+## 4. Cleanup
+
+- [ ] 4.1 Run `gx branch finish --branch agent/codex/release-7-0-27-2026-04-23 --base main --via-pr --wait-for-merge --cleanup`.
+- [ ] 4.2 Record PR URL + final `MERGED` state in the completion handoff.
+- [ ] 4.3 Confirm sandbox cleanup with `git worktree list` and `git branch -a`.

--- a/openspec/changes/agent-codex-release-guardex-7-0-27-2026-04-23/tasks.md
+++ b/openspec/changes/agent-codex-release-guardex-7-0-27-2026-04-23/tasks.md
@@ -21,5 +21,5 @@
 ## 4. Cleanup
 
 - [ ] 4.1 Run `gx branch finish --branch agent/codex/release-7-0-27-2026-04-23 --base main --via-pr --wait-for-merge --cleanup`.
-- [ ] 4.2 Record PR URL + final `MERGED` state in the completion handoff.
+- [ ] 4.2 Record PR URL + final `MERGED` state in the completion handoff. PR: `https://github.com/recodeee/gitguardex/pull/399`.
 - [ ] 4.3 Confirm sandbox cleanup with `git worktree list` and `git branch -a`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "7.0.26",
+  "version": "7.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@imdeadpool/guardex",
-      "version": "7.0.26",
+      "version": "7.0.27",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "7.0.26",
+  "version": "7.0.27",
   "description": "Guardian T-Rex for your multi-agent repo. Isolated worktrees, file locks, and PR-only merges stop parallel Codex & Claude agents from overwriting each other's work. Auto-wires Oh My Codex, Oh My Claude, OpenSpec, and Caveman.",
   "license": "MIT",
   "preferGlobal": true,


### PR DESCRIPTION
## Summary
- bump @imdeadpool/guardex from 7.0.26 to 7.0.27
- add README release notes for the shipped branch-start and PR-only finish fixes already merged on main
- record the release-only OpenSpec change for the publishable version bump

## Verification
- node --test test/metadata.test.js
- node --check bin/multiagent-safety.js
- npm pack --dry-run
- openspec validate agent-codex-release-guardex-7-0-27-2026-04-23 --type change --strict
- openspec validate --specs
- git diff --check