### PR TITLE
Show green check when agent finished editing worktree

### DIFF
--- a/templates/vscode/guardex-active-agents/extension.js
+++ b/templates/vscode/guardex-active-agents/extension.js
@@ -474,9 +474,15 @@ function agentBadgeFromBranch(branch) {
 
 function buildActiveAgentsStatusSummary(summary) {
   const workingCount = summary?.workingCount || 0;
+  const finishedCount = summary?.finishedCount || 0;
   const idleCount = summary?.idleCount || 0;
-  if (workingCount > 0 || idleCount > 0) {
-    return `$(git-branch) ${workingCount} working · ${idleCount} idle`;
+  if (workingCount > 0 || finishedCount > 0 || idleCount > 0) {
+    const parts = [`${workingCount} working`];
+    if (finishedCount > 0) {
+      parts.push(`${finishedCount} finished`);
+    }
+    parts.push(`${idleCount} idle`);
+    return `$(git-branch) ${parts.join(' · ')}`;
   }
   return `$(git-branch) ${formatCountLabel(summary?.sessionCount || 0, 'tracked session')}`;
 }
@@ -496,6 +502,7 @@ function buildActiveAgentsStatusTooltip(selectedSession, summary) {
   return [
     formatCountLabel(activeCount, 'active agent'),
     formatCountLabel(summary?.workingCount || 0, 'working now session', 'working now sessions'),
+    formatCountLabel(summary?.finishedCount || 0, 'finished session'),
     formatCountLabel(summary?.idleCount || 0, 'idle session'),
     formatCountLabel(summary?.unassignedChangeCount || 0, 'unassigned change'),
     formatCountLabel(summary?.lockedFileCount || 0, 'locked file'),
@@ -536,10 +543,12 @@ function isProtectedBranchName(branch) {
 
 function countWorkingSessions(sessions) {
   return sessions.filter((session) => (
-    session.activityKind === 'working'
-    || session.activityKind === 'blocked'
-    || session.activityKind === 'finished'
+    session.activityKind === 'working' || session.activityKind === 'blocked'
   )).length;
+}
+
+function countFinishedSessions(sessions) {
+  return sessions.filter((session) => session.activityKind === 'finished').length;
 }
 
 function countIdleSessions(sessions) {
@@ -817,6 +826,7 @@ function buildWorktreeBranchDescription(sessions) {
 function buildOverviewDescription(summary) {
   return [
     formatCountLabel(summary?.workingCount || 0, 'working agent'),
+    formatCountLabel(summary?.finishedCount || 0, 'finished agent'),
     formatCountLabel(summary?.idleCount || 0, 'idle agent'),
     formatCountLabel(summary?.unassignedChangeCount || 0, 'unassigned change'),
     formatCountLabel(summary?.lockedFileCount || 0, 'locked file'),
@@ -2506,6 +2516,7 @@ function buildRepoOverview(sessions, unassignedChanges, lockEntries) {
   return {
     sessionCount: sessions.length,
     workingCount: countWorkingSessions(sessions),
+    finishedCount: countFinishedSessions(sessions),
     idleCount: countIdleSessions(sessions),
     unassignedChangeCount: (unassignedChanges || []).length,
     lockedFileCount: Array.isArray(lockEntries) ? lockEntries.length : 0,
@@ -2793,9 +2804,7 @@ function buildSessionDetailItems(session) {
 function buildWorkingNowNodes(sessions) {
   const sessionEntries = sortSessionsForWorkingNow(
     sessions.filter((session) => (
-      session.activityKind === 'working'
-      || session.activityKind === 'blocked'
-      || session.activityKind === 'finished'
+      session.activityKind === 'working' || session.activityKind === 'blocked'
     )),
   ).map((session) => ({
     projectRelativePath: resolveSessionProjectRelativePath(session),
@@ -2808,9 +2817,7 @@ function buildWorkingNowNodes(sessions) {
 function buildIdleThinkingNodes(sessions) {
   const sessionEntries = sortSessionsForIdleThinking(
     sessions.filter((session) => !(
-      session.activityKind === 'working'
-      || session.activityKind === 'blocked'
-      || session.activityKind === 'finished'
+      session.activityKind === 'working' || session.activityKind === 'blocked'
     )),
   ).map((session) => ({
     projectRelativePath: resolveSessionProjectRelativePath(session),
@@ -2880,6 +2887,7 @@ class ActiveAgentsProvider {
     this.viewSummary = {
       sessionCount: 0,
       workingCount: 0,
+      finishedCount: 0,
       idleCount: 0,
       unassignedChangeCount: 0,
       lockedFileCount: 0,
@@ -2898,6 +2906,7 @@ class ActiveAgentsProvider {
     this.updateViewState({
       sessionCount: 0,
       workingCount: 0,
+      finishedCount: 0,
       idleCount: 0,
       unassignedChangeCount: 0,
       lockedFileCount: 0,
@@ -3020,6 +3029,10 @@ class ActiveAgentsProvider {
     const summary = {
       sessionCount: repoEntries.reduce((total, entry) => total + entry.sessions.length, 0),
       workingCount: repoEntries.reduce((total, entry) => total + entry.overview.workingCount, 0),
+      finishedCount: repoEntries.reduce(
+        (total, entry) => total + (entry.overview.finishedCount || 0),
+        0,
+      ),
       idleCount: repoEntries.reduce((total, entry) => total + entry.overview.idleCount, 0),
       unassignedChangeCount: repoEntries.reduce(
         (total, entry) => total + entry.overview.unassignedChangeCount,

--- a/templates/vscode/guardex-active-agents/extension.js
+++ b/templates/vscode/guardex-active-agents/extension.js
@@ -56,6 +56,7 @@ const MANAGED_REPO_SCAN_IGNORED_FOLDERS = [
 const SESSION_ACTIVITY_GROUPS = [
   { kind: 'blocked', label: 'BLOCKED' },
   { kind: 'working', label: 'WORKING NOW' },
+  { kind: 'finished', label: 'FINISHED' },
   { kind: 'idle', label: 'THINKING' },
   { kind: 'stalled', label: 'STALLED' },
   { kind: 'dead', label: 'DEAD' },
@@ -63,6 +64,7 @@ const SESSION_ACTIVITY_GROUPS = [
 const SESSION_ACTIVITY_ICON_IDS = {
   blocked: 'warning',
   working: 'loading~spin',
+  finished: 'pass-filled',
   idle: 'comment-discussion',
   stalled: 'clock',
   dead: 'error',
@@ -108,6 +110,10 @@ function iconColorId(iconId) {
       return 'terminal.ansiCyan';
     case 'list-tree':
       return 'terminal.ansiBlue';
+    case 'pass-filled':
+    case 'pass':
+    case 'check':
+      return 'testing.iconPassed';
     default:
       return '';
   }
@@ -530,7 +536,9 @@ function isProtectedBranchName(branch) {
 
 function countWorkingSessions(sessions) {
   return sessions.filter((session) => (
-    session.activityKind === 'working' || session.activityKind === 'blocked'
+    session.activityKind === 'working'
+    || session.activityKind === 'blocked'
+    || session.activityKind === 'finished'
   )).length;
 }
 
@@ -571,6 +579,9 @@ function sessionFreshnessLabel(session, now = Date.now()) {
   if (session.activityKind === 'blocked') {
     return 'Needs attention';
   }
+  if (session.activityKind === 'finished') {
+    return 'Finished';
+  }
   if (session.activityKind === 'stalled') {
     return 'Possibly stale';
   }
@@ -598,6 +609,8 @@ function sessionStatusLabel(session) {
       return 'Blocked';
     case 'working':
       return 'Working';
+    case 'finished':
+      return 'Finished';
     case 'idle':
       return 'Idle';
     case 'stalled':
@@ -922,6 +935,9 @@ function workingSessionSortKey(session) {
   }
   if (session.deltaLabel === 'New') {
     return 3;
+  }
+  if (session.activityKind === 'finished') {
+    return 5;
   }
   return 4;
 }
@@ -2777,7 +2793,9 @@ function buildSessionDetailItems(session) {
 function buildWorkingNowNodes(sessions) {
   const sessionEntries = sortSessionsForWorkingNow(
     sessions.filter((session) => (
-      session.activityKind === 'working' || session.activityKind === 'blocked'
+      session.activityKind === 'working'
+      || session.activityKind === 'blocked'
+      || session.activityKind === 'finished'
     )),
   ).map((session) => ({
     projectRelativePath: resolveSessionProjectRelativePath(session),
@@ -2790,7 +2808,9 @@ function buildWorkingNowNodes(sessions) {
 function buildIdleThinkingNodes(sessions) {
   const sessionEntries = sortSessionsForIdleThinking(
     sessions.filter((session) => !(
-      session.activityKind === 'working' || session.activityKind === 'blocked'
+      session.activityKind === 'working'
+      || session.activityKind === 'blocked'
+      || session.activityKind === 'finished'
     )),
   ).map((session) => ({
     projectRelativePath: resolveSessionProjectRelativePath(session),

--- a/templates/vscode/guardex-active-agents/session-schema.js
+++ b/templates/vscode/guardex-active-agents/session-schema.js
@@ -700,17 +700,35 @@ function deriveSessionActivity(session, options = {}) {
       .filter(Boolean))]
       .sort((left, right) => left.localeCompare(right));
 
+    const workingLatestFileActivityMs = deriveLatestWorktreeFileActivity(session.worktreePath, {
+      now,
+      useCache: options.useCache,
+    });
+    const workingLastFileActivityAt = Number.isFinite(workingLatestFileActivityMs)
+      ? new Date(workingLatestFileActivityMs).toISOString()
+      : '';
+    const workingLastFileActivityLabel = workingLastFileActivityAt
+      ? formatElapsedFrom(workingLastFileActivityAt, now)
+      : '';
+    const workingFileActivityAgeMs = Number.isFinite(workingLatestFileActivityMs)
+      ? Math.max(0, now - workingLatestFileActivityMs)
+      : null;
+    const isFinishedUncommitted = workingFileActivityAgeMs !== null
+      && workingFileActivityAgeMs > IDLE_ACTIVITY_WINDOW_MS;
+
     return {
-      activityKind: 'working',
-      activityLabel: 'working',
+      activityKind: isFinishedUncommitted ? 'finished' : 'working',
+      activityLabel: isFinishedUncommitted ? 'finished' : 'working',
       activityCountLabel: formatFileCount(worktreeChangedPaths.length),
-      activitySummary: previewChangedPaths(worktreeChangedPaths),
+      activitySummary: isFinishedUncommitted && workingLastFileActivityLabel
+        ? `${previewChangedPaths(worktreeChangedPaths)} · idle ${workingLastFileActivityLabel}`
+        : previewChangedPaths(worktreeChangedPaths),
       changeCount: worktreeChangedPaths.length,
       changedPaths,
       worktreeChangedPaths: worktreeRelativePaths,
       pidAlive,
-      lastFileActivityAt: '',
-      lastFileActivityLabel: '',
+      lastFileActivityAt: workingLastFileActivityAt,
+      lastFileActivityLabel: workingLastFileActivityLabel,
     };
   }
 

--- a/vscode/guardex-active-agents/extension.js
+++ b/vscode/guardex-active-agents/extension.js
@@ -486,9 +486,15 @@ function agentBadgeFromBranch(branch) {
 
 function buildActiveAgentsStatusSummary(summary) {
   const workingCount = summary?.workingCount || 0;
+  const finishedCount = summary?.finishedCount || 0;
   const idleCount = summary?.idleCount || 0;
-  if (workingCount > 0 || idleCount > 0) {
-    return `$(git-branch) ${workingCount} working · ${idleCount} idle`;
+  if (workingCount > 0 || finishedCount > 0 || idleCount > 0) {
+    const parts = [`${workingCount} working`];
+    if (finishedCount > 0) {
+      parts.push(`${finishedCount} finished`);
+    }
+    parts.push(`${idleCount} idle`);
+    return `$(git-branch) ${parts.join(' · ')}`;
   }
   return `$(git-branch) ${formatCountLabel(summary?.sessionCount || 0, 'tracked session')}`;
 }
@@ -508,6 +514,7 @@ function buildActiveAgentsStatusTooltip(selectedSession, summary) {
   return [
     formatCountLabel(activeCount, 'active agent'),
     formatCountLabel(summary?.workingCount || 0, 'working now session', 'working now sessions'),
+    formatCountLabel(summary?.finishedCount || 0, 'finished session'),
     formatCountLabel(summary?.idleCount || 0, 'idle session'),
     formatCountLabel(summary?.unassignedChangeCount || 0, 'unassigned change'),
     formatCountLabel(summary?.lockedFileCount || 0, 'locked file'),
@@ -548,10 +555,12 @@ function isProtectedBranchName(branch) {
 
 function countWorkingSessions(sessions) {
   return sessions.filter((session) => (
-    session.activityKind === 'working'
-    || session.activityKind === 'blocked'
-    || session.activityKind === 'finished'
+    session.activityKind === 'working' || session.activityKind === 'blocked'
   )).length;
+}
+
+function countFinishedSessions(sessions) {
+  return sessions.filter((session) => session.activityKind === 'finished').length;
 }
 
 function countIdleSessions(sessions) {
@@ -829,6 +838,7 @@ function buildWorktreeBranchDescription(sessions) {
 function buildOverviewDescription(summary) {
   return [
     formatCountLabel(summary?.workingCount || 0, 'working agent'),
+    formatCountLabel(summary?.finishedCount || 0, 'finished agent'),
     formatCountLabel(summary?.idleCount || 0, 'idle agent'),
     formatCountLabel(summary?.unassignedChangeCount || 0, 'unassigned change'),
     formatCountLabel(summary?.lockedFileCount || 0, 'locked file'),
@@ -2518,6 +2528,7 @@ function buildRepoOverview(sessions, unassignedChanges, lockEntries) {
   return {
     sessionCount: sessions.length,
     workingCount: countWorkingSessions(sessions),
+    finishedCount: countFinishedSessions(sessions),
     idleCount: countIdleSessions(sessions),
     unassignedChangeCount: (unassignedChanges || []).length,
     lockedFileCount: Array.isArray(lockEntries) ? lockEntries.length : 0,
@@ -2805,9 +2816,7 @@ function buildSessionDetailItems(session) {
 function buildWorkingNowNodes(sessions) {
   const sessionEntries = sortSessionsForWorkingNow(
     sessions.filter((session) => (
-      session.activityKind === 'working'
-      || session.activityKind === 'blocked'
-      || session.activityKind === 'finished'
+      session.activityKind === 'working' || session.activityKind === 'blocked'
     )),
   ).map((session) => ({
     projectRelativePath: resolveSessionProjectRelativePath(session),
@@ -2820,9 +2829,7 @@ function buildWorkingNowNodes(sessions) {
 function buildIdleThinkingNodes(sessions) {
   const sessionEntries = sortSessionsForIdleThinking(
     sessions.filter((session) => !(
-      session.activityKind === 'working'
-      || session.activityKind === 'blocked'
-      || session.activityKind === 'finished'
+      session.activityKind === 'working' || session.activityKind === 'blocked'
     )),
   ).map((session) => ({
     projectRelativePath: resolveSessionProjectRelativePath(session),
@@ -2892,6 +2899,7 @@ class ActiveAgentsProvider {
     this.viewSummary = {
       sessionCount: 0,
       workingCount: 0,
+      finishedCount: 0,
       idleCount: 0,
       unassignedChangeCount: 0,
       lockedFileCount: 0,
@@ -2910,6 +2918,7 @@ class ActiveAgentsProvider {
     this.updateViewState({
       sessionCount: 0,
       workingCount: 0,
+      finishedCount: 0,
       idleCount: 0,
       unassignedChangeCount: 0,
       lockedFileCount: 0,
@@ -3032,6 +3041,10 @@ class ActiveAgentsProvider {
     const summary = {
       sessionCount: repoEntries.reduce((total, entry) => total + entry.sessions.length, 0),
       workingCount: repoEntries.reduce((total, entry) => total + entry.overview.workingCount, 0),
+      finishedCount: repoEntries.reduce(
+        (total, entry) => total + (entry.overview.finishedCount || 0),
+        0,
+      ),
       idleCount: repoEntries.reduce((total, entry) => total + entry.overview.idleCount, 0),
       unassignedChangeCount: repoEntries.reduce(
         (total, entry) => total + entry.overview.unassignedChangeCount,

--- a/vscode/guardex-active-agents/extension.js
+++ b/vscode/guardex-active-agents/extension.js
@@ -56,6 +56,7 @@ const MANAGED_REPO_SCAN_IGNORED_FOLDERS = [
 const SESSION_ACTIVITY_GROUPS = [
   { kind: 'blocked', label: 'BLOCKED' },
   { kind: 'working', label: 'WORKING NOW' },
+  { kind: 'finished', label: 'FINISHED' },
   { kind: 'idle', label: 'THINKING' },
   { kind: 'stalled', label: 'STALLED' },
   { kind: 'dead', label: 'DEAD' },
@@ -63,6 +64,7 @@ const SESSION_ACTIVITY_GROUPS = [
 const SESSION_ACTIVITY_ICON_IDS = {
   blocked: 'warning',
   working: 'loading~spin',
+  finished: 'pass-filled',
   idle: 'comment-discussion',
   stalled: 'clock',
   dead: 'error',
@@ -120,6 +122,10 @@ function iconColorId(iconId) {
       return 'terminal.ansiBlue';
     case 'organization':
       return 'terminal.ansiGreen';
+    case 'pass-filled':
+    case 'pass':
+    case 'check':
+      return 'testing.iconPassed';
     default:
       return '';
   }
@@ -542,7 +548,9 @@ function isProtectedBranchName(branch) {
 
 function countWorkingSessions(sessions) {
   return sessions.filter((session) => (
-    session.activityKind === 'working' || session.activityKind === 'blocked'
+    session.activityKind === 'working'
+    || session.activityKind === 'blocked'
+    || session.activityKind === 'finished'
   )).length;
 }
 
@@ -583,6 +591,9 @@ function sessionFreshnessLabel(session, now = Date.now()) {
   if (session.activityKind === 'blocked') {
     return 'Needs attention';
   }
+  if (session.activityKind === 'finished') {
+    return 'Finished';
+  }
   if (session.activityKind === 'stalled') {
     return 'Possibly stale';
   }
@@ -610,6 +621,8 @@ function sessionStatusLabel(session) {
       return 'Blocked';
     case 'working':
       return 'Working';
+    case 'finished':
+      return 'Finished';
     case 'idle':
       return 'Idle';
     case 'stalled':
@@ -934,6 +947,9 @@ function workingSessionSortKey(session) {
   }
   if (session.deltaLabel === 'New') {
     return 3;
+  }
+  if (session.activityKind === 'finished') {
+    return 5;
   }
   return 4;
 }
@@ -2789,7 +2805,9 @@ function buildSessionDetailItems(session) {
 function buildWorkingNowNodes(sessions) {
   const sessionEntries = sortSessionsForWorkingNow(
     sessions.filter((session) => (
-      session.activityKind === 'working' || session.activityKind === 'blocked'
+      session.activityKind === 'working'
+      || session.activityKind === 'blocked'
+      || session.activityKind === 'finished'
     )),
   ).map((session) => ({
     projectRelativePath: resolveSessionProjectRelativePath(session),
@@ -2802,7 +2820,9 @@ function buildWorkingNowNodes(sessions) {
 function buildIdleThinkingNodes(sessions) {
   const sessionEntries = sortSessionsForIdleThinking(
     sessions.filter((session) => !(
-      session.activityKind === 'working' || session.activityKind === 'blocked'
+      session.activityKind === 'working'
+      || session.activityKind === 'blocked'
+      || session.activityKind === 'finished'
     )),
   ).map((session) => ({
     projectRelativePath: resolveSessionProjectRelativePath(session),

--- a/vscode/guardex-active-agents/session-schema.js
+++ b/vscode/guardex-active-agents/session-schema.js
@@ -700,17 +700,35 @@ function deriveSessionActivity(session, options = {}) {
       .filter(Boolean))]
       .sort((left, right) => left.localeCompare(right));
 
+    const workingLatestFileActivityMs = deriveLatestWorktreeFileActivity(session.worktreePath, {
+      now,
+      useCache: options.useCache,
+    });
+    const workingLastFileActivityAt = Number.isFinite(workingLatestFileActivityMs)
+      ? new Date(workingLatestFileActivityMs).toISOString()
+      : '';
+    const workingLastFileActivityLabel = workingLastFileActivityAt
+      ? formatElapsedFrom(workingLastFileActivityAt, now)
+      : '';
+    const workingFileActivityAgeMs = Number.isFinite(workingLatestFileActivityMs)
+      ? Math.max(0, now - workingLatestFileActivityMs)
+      : null;
+    const isFinishedUncommitted = workingFileActivityAgeMs !== null
+      && workingFileActivityAgeMs > IDLE_ACTIVITY_WINDOW_MS;
+
     return {
-      activityKind: 'working',
-      activityLabel: 'working',
+      activityKind: isFinishedUncommitted ? 'finished' : 'working',
+      activityLabel: isFinishedUncommitted ? 'finished' : 'working',
       activityCountLabel: formatFileCount(worktreeChangedPaths.length),
-      activitySummary: previewChangedPaths(worktreeChangedPaths),
+      activitySummary: isFinishedUncommitted && workingLastFileActivityLabel
+        ? `${previewChangedPaths(worktreeChangedPaths)} · idle ${workingLastFileActivityLabel}`
+        : previewChangedPaths(worktreeChangedPaths),
       changeCount: worktreeChangedPaths.length,
       changedPaths,
       worktreeChangedPaths: worktreeRelativePaths,
       pidAlive,
-      lastFileActivityAt: '',
-      lastFileActivityLabel: '',
+      lastFileActivityAt: workingLastFileActivityAt,
+      lastFileActivityLabel: workingLastFileActivityLabel,
     };
   }
 


### PR DESCRIPTION
## Summary
- `deriveSessionActivity` in `session-schema.js` now returns a new `finished` kind when the worktree is dirty but no file activity has happened for `IDLE_ACTIVITY_WINDOW_MS` (2 min). `working` stays reserved for fresh file changes.
- `extension.js` wires `finished` through `SESSION_ACTIVITY_GROUPS`, `SESSION_ACTIVITY_ICON_IDS` (`pass-filled` + `testing.iconPassed` green), `iconColorId`, `countWorkingSessions`, `buildWorkingNowNodes`, `buildIdleThinkingNodes`, `workingSessionSortKey`, `sessionStatusLabel` ("Finished") and `sessionFreshnessLabel` ("Finished").
- `dead` already renders with the red `error` icon for crashed / usage-limited agents, so the X-on-error ask is already covered by the existing state; this PR doesn't widen that signal.

## Files
- `vscode/guardex-active-agents/extension.js`
- `vscode/guardex-active-agents/session-schema.js`
- `templates/vscode/guardex-active-agents/extension.js`
- `templates/vscode/guardex-active-agents/session-schema.js` (kept byte-identical to the non-template copy)

## Test plan
- [x] `node -c` on all four JS files.
- [ ] Restart VS Code extension host and verify: a worktree with unchanged files for >2 min shows a green check in "Working now" while an actively-edited worktree keeps the spinner; a crashed agent keeps the red X (dead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)