### PR TITLE
Group gx help commands + quickstart and bump to 7.0.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,12 @@ npm pack --dry-run
 <details>
 <summary><strong>v7.x</strong></summary>
 
+### v7.0.28
+- Bumped `@imdeadpool/guardex` from `7.0.27` to `7.0.28` so the CLI help redesign can ship on a fresh npm version.
+- `gx --help` and `gx` (no args) now render commands as a grouped catalog (Setup & health / Branch workflow / Coordination / Agents & reports / Meta) with short group descriptions, so the top of the help screen shows the newcomer path instead of a flat 20-row list.
+- Added a three-step Quickstart block (`gx setup` → `gx branch start "<task>" "<agent>"` → `gx branch finish --via-pr --wait-for-merge --cleanup`) to both help surfaces so the intended install/setup sequence is visible before the full command reference.
+- Exposed `CLI_COMMAND_GROUPS` and `CLI_QUICKSTART_STEPS` from `src/context.js` (with `CLI_COMMAND_DESCRIPTIONS` derived from the grouped source of truth), giving future help tooling and integrations a structured way to iterate the catalog without re-parsing flat rows.
+
 ### v7.0.27
 - Bumped `@imdeadpool/guardex` from `7.0.26` to `7.0.27` so npm can publish a fresh version after `7.0.26` was already taken on the registry.
 - The shipped `agent-branch-start.sh` copies now keep the startup auto-transfer path alive under `set -o pipefail`, so Guardex can still restore moved changes back to the protected checkout when branch startup hits a later failure.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "7.0.27",
+  "version": "7.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@imdeadpool/guardex",
-      "version": "7.0.27",
+      "version": "7.0.28",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "7.0.27",
+  "version": "7.0.28",
   "description": "Guardian T-Rex for your multi-agent repo. Isolated worktrees, file locks, and PR-only merges stop parallel Codex & Claude agents from overwriting each other's work. Auto-wires Oh My Codex, Oh My Claude, OpenSpec, and Caveman.",
   "license": "MIT",
   "preferGlobal": true,

--- a/src/context.js
+++ b/src/context.js
@@ -363,27 +363,68 @@ const SUGGESTIBLE_COMMANDS = [
   'print-agents-snippet',
   'release',
 ];
-const CLI_COMMAND_DESCRIPTIONS = [
-  ['status', 'Show GitGuardex CLI + service health without modifying files'],
-  ['setup', 'Install, repair, and verify guardrails (flags: --repair, --install-only, --target, --current)'],
-  ['doctor', 'Repair drift + verify (flags: --target, --current; auto-sandboxes on protected main)'],
-  ['branch', 'CLI-owned branch workflow surface (start/finish/merge)'],
-  ['locks', 'CLI-owned file lock surface (claim/allow-delete/release/status/validate)'],
-  ['worktree', 'CLI-owned worktree cleanup surface (prune)'],
-  ['hook', 'Hook dispatch/install surface used by managed shims'],
-  ['migrate', 'Convert legacy repo-local installs to the zero-copy CLI-owned surface'],
-  ['install-agent-skills', 'Install Guardex Codex/Claude skills into the user home'],
-  ['protect', 'Manage protected branches (list/add/remove/set/reset)'],
-  ['merge', 'Create/reuse an integration lane and merge overlapping agent branches'],
-  ['sync', 'Sync agent branches with origin/<base>'],
-  ['finish', 'Commit + PR + merge completed agent branches (--all, --branch)'],
-  ['cleanup', 'Prune merged/stale agent branches and worktrees'],
-  ['release', 'Create or update the current GitHub release with README-generated notes'],
-  ['agents', 'Start/stop repo-scoped review + cleanup bots'],
-  ['prompt', 'Print AI setup checklist or named slices (--exec, --part, --list-parts, --snippet)'],
-  ['report', 'Security/safety reports (e.g. OpenSSF scorecard, session severity)'],
-  ['help', 'Show this help output'],
-  ['version', 'Print GitGuardex version'],
+// CLI_COMMAND_GROUPS is the grouped source of truth the `gx --help` /
+// `gx` no-args renderer uses. Each group is ordered roughly by how often a
+// user reaches for it so the help screen answers "what do I run first?"
+// before "what else can this do?". CLI_COMMAND_DESCRIPTIONS preserves the
+// flat export for callers that still want the ungrouped list.
+const CLI_COMMAND_GROUPS = [
+  {
+    label: 'Setup & health',
+    description: 'Install, repair, and check a repo. Run these first on a new clone.',
+    commands: [
+      ['setup', 'Install, repair, and verify guardrails (flags: --repair, --install-only, --target, --current)'],
+      ['doctor', 'Repair drift + verify (flags: --target, --current; auto-sandboxes on protected main)'],
+      ['status', 'Show GitGuardex CLI + service health without modifying files'],
+      ['migrate', 'Convert legacy repo-local installs to the zero-copy CLI-owned surface'],
+    ],
+  },
+  {
+    label: 'Branch workflow',
+    description: 'The sandbox → commit → PR → merge loop for agent-owned branches.',
+    commands: [
+      ['branch', 'CLI-owned branch workflow surface (start/finish/merge)'],
+      ['finish', 'Commit + PR + merge completed agent branches (--all, --branch)'],
+      ['merge', 'Create/reuse an integration lane and merge overlapping agent branches'],
+      ['sync', 'Sync agent branches with origin/<base>'],
+      ['cleanup', 'Prune merged/stale agent branches and worktrees'],
+    ],
+  },
+  {
+    label: 'Coordination',
+    description: 'File locks, worktrees, hooks, and protected-branch policy.',
+    commands: [
+      ['locks', 'CLI-owned file lock surface (claim/allow-delete/release/status/validate)'],
+      ['worktree', 'CLI-owned worktree cleanup surface (prune)'],
+      ['hook', 'Hook dispatch/install surface used by managed shims'],
+      ['protect', 'Manage protected branches (list/add/remove/set/reset)'],
+    ],
+  },
+  {
+    label: 'Agents & reports',
+    description: 'Review / cleanup bots, AI setup prompts, and safety reports.',
+    commands: [
+      ['agents', 'Start/stop repo-scoped review + cleanup bots'],
+      ['install-agent-skills', 'Install Guardex Codex/Claude skills into the user home'],
+      ['prompt', 'Print AI setup checklist or named slices (--exec, --part, --list-parts, --snippet)'],
+      ['report', 'Security/safety reports (e.g. OpenSSF scorecard, session severity)'],
+      ['release', 'Create or update the current GitHub release with README-generated notes'],
+    ],
+  },
+  {
+    label: 'Meta',
+    description: 'Version + help.',
+    commands: [
+      ['help', 'Show this help output'],
+      ['version', 'Print GitGuardex version'],
+    ],
+  },
+];
+const CLI_COMMAND_DESCRIPTIONS = CLI_COMMAND_GROUPS.flatMap((group) => group.commands);
+const CLI_QUICKSTART_STEPS = [
+  'gx setup',
+  'gx branch start "<task>" "<agent>"',
+  'gx branch finish --via-pr --wait-for-merge --cleanup',
 ];
 const DEPRECATED_COMMAND_ALIASES = new Map([
   ['init', { target: 'setup', hint: 'gx setup' }],
@@ -686,6 +727,8 @@ module.exports = {
   COMMAND_TYPO_ALIASES,
   SUGGESTIBLE_COMMANDS,
   CLI_COMMAND_DESCRIPTIONS,
+  CLI_COMMAND_GROUPS,
+  CLI_QUICKSTART_STEPS,
   DEPRECATED_COMMAND_ALIASES,
   AGENT_BOT_DESCRIPTIONS,
   DOCTOR_AUTO_FINISH_DETAIL_LIMIT,

--- a/src/output/index.js
+++ b/src/output/index.js
@@ -6,6 +6,8 @@ const {
   LEGACY_NAMES,
   GUARDEX_REPO_TOGGLE_ENV,
   CLI_COMMAND_DESCRIPTIONS,
+  CLI_COMMAND_GROUPS,
+  CLI_QUICKSTART_STEPS,
   AGENT_BOT_DESCRIPTIONS,
   DOCTOR_AUTO_FINISH_DETAIL_LIMIT,
   DOCTOR_AUTO_FINISH_BRANCH_LABEL_MAX,
@@ -166,6 +168,41 @@ function commandCatalogLines(indent = '  ') {
   );
 }
 
+// groupedCommandCatalogLines renders CLI_COMMAND_GROUPS as a nested list with
+// group headers separated by blank lines. It accepts an optional `colorize`
+// callback so the caller can decide whether to decorate the group label (tty
+// mode) or leave it plain (non-tty / NO_COLOR). Returns an array of lines;
+// `null` entries mean "emit a blank line" so tree renderers can echo pipe
+// characters on the separator rows.
+function groupedCommandCatalogLines(indent = '  ', options = {}) {
+  const colorizeLabel = typeof options.colorizeLabel === 'function'
+    ? options.colorizeLabel
+    : (text) => text;
+  const maxCommandLength = CLI_COMMAND_DESCRIPTIONS.reduce(
+    (max, [command]) => Math.max(max, command.length),
+    0,
+  );
+  const lines = [];
+  for (let groupIndex = 0; groupIndex < CLI_COMMAND_GROUPS.length; groupIndex += 1) {
+    const group = CLI_COMMAND_GROUPS[groupIndex];
+    const header = group.description
+      ? `${colorizeLabel(group.label)} — ${group.description}`
+      : colorizeLabel(group.label);
+    lines.push(`${indent}${header}`);
+    for (const [command, description] of group.commands) {
+      lines.push(`${indent}  ${command.padEnd(maxCommandLength + 2)}${description}`);
+    }
+    if (groupIndex < CLI_COMMAND_GROUPS.length - 1) {
+      lines.push(null);
+    }
+  }
+  return lines;
+}
+
+function quickstartLines(indent = '  ') {
+  return CLI_QUICKSTART_STEPS.map((step, index) => `${indent}${index + 1}. ${step}`);
+}
+
 function agentBotCatalogLines(indent = '  ') {
   const maxCommandLength = AGENT_BOT_DESCRIPTIONS.reduce(
     (max, [command]) => Math.max(max, command.length),
@@ -184,17 +221,22 @@ function repoToggleLines(indent = '  ') {
 
 function printToolLogsSummary() {
   const usageLine = `    $ ${SHORT_TOOL_NAME} <command> [options]`;
-  const commandDetails = commandCatalogLines('    ');
+  const quickstartDetails = quickstartLines('    ');
   const agentBotDetails = agentBotCatalogLines('    ');
   const repoToggleDetails = repoToggleLines('    ');
 
   if (!supportsAnsiColors()) {
+    const commandDetails = groupedCommandCatalogLines('    ');
     console.log(`${TOOL_NAME}-tools logs:`);
     console.log('  USAGE');
     console.log(usageLine);
+    console.log('  QUICKSTART');
+    for (const line of quickstartDetails) {
+      console.log(line);
+    }
     console.log('  COMMANDS');
     for (const line of commandDetails) {
-      console.log(line);
+      console.log(line ?? '');
     }
     console.log('  AGENT BOT');
     for (const line of agentBotDetails) {
@@ -209,19 +251,27 @@ function printToolLogsSummary() {
 
   const title = colorize(`${TOOL_NAME}-tools logs`, '1;36');
   const usageHeader = colorize('USAGE', '1');
+  const quickstartHeader = colorize('QUICKSTART', '1');
   const commandsHeader = colorize('COMMANDS', '1');
   const agentBotHeader = colorize('AGENT BOT', '1');
   const repoToggleHeader = colorize('REPO TOGGLE', '1');
   const pipe = colorize('│', '90');
   const tee = colorize('├', '90');
   const corner = colorize('└', '90');
+  const commandDetails = groupedCommandCatalogLines('    ', {
+    colorizeLabel: (text) => colorize(text, '1;36'),
+  });
 
   console.log(`${title}:`);
   console.log(`  ${tee}─ ${usageHeader}`);
   console.log(`  ${pipe}${usageLine}`);
+  console.log(`  ${tee}─ ${quickstartHeader}`);
+  for (const line of quickstartDetails) {
+    console.log(`  ${pipe}${line.slice(2)}`);
+  }
   console.log(`  ${tee}─ ${commandsHeader}`);
   for (const line of commandDetails) {
-    if (!line) {
+    if (line == null) {
       console.log(`  ${pipe}`);
       continue;
     }
@@ -249,6 +299,12 @@ function printToolLogsSummary() {
 function usage(options = {}) {
   const { outsideGitRepo = false } = options;
 
+  const groupedCommandLines = groupedCommandCatalogLines('  ', {
+    colorizeLabel: (text) => colorize(text, '1;36'),
+  })
+    .map((line) => (line == null ? '' : line))
+    .join('\n');
+
   console.log(`A command-line tool that sets up hardened multi-agent safety for git repositories.
 
 VERSION
@@ -257,8 +313,11 @@ VERSION
 USAGE
   $ ${SHORT_TOOL_NAME} <command> [options]
 
+QUICKSTART
+${quickstartLines().join('\n')}
+
 COMMANDS
-${commandCatalogLines().join('\n')}
+${groupedCommandLines}
 
 AGENT BOT
 ${agentBotCatalogLines().join('\n')}


### PR DESCRIPTION
## Summary

Before:

\`\`\`
COMMANDS
  status                Show GitGuardex CLI + service health ...
  setup                 Install, repair, and verify guardrails ...
  doctor                Repair drift + verify ...
  branch                CLI-owned branch workflow surface ...
  (… 16 more flat rows …)
\`\`\`

A first-time user had to scan the whole 20-row list to figure out the intended \"install → setup → first branch\" sequence. This restructures the help surface into a grouped catalog with a Quickstart block that makes the bootstrap path visible up-front.

After (`gx --help` or `gx` with no args):

- **QUICKSTART**
  1. \`gx setup\`
  2. \`gx branch start \"<task>\" \"<agent>\"\`
  3. \`gx branch finish --via-pr --wait-for-merge --cleanup\`
- **COMMANDS** (grouped)
  - Setup & health — Install, repair, and check a repo. Run these first on a new clone.
  - Branch workflow — The sandbox → commit → PR → merge loop for agent-owned branches.
  - Coordination — File locks, worktrees, hooks, and protected-branch policy.
  - Agents & reports — Review / cleanup bots, AI setup prompts, and safety reports.
  - Meta — Version + help.

## Changes

- \`src/context.js\`: add \`CLI_COMMAND_GROUPS\` and \`CLI_QUICKSTART_STEPS\` as the grouped source of truth; derive \`CLI_COMMAND_DESCRIPTIONS\` from the groups so existing callers keep working.
- \`src/output/index.js\`: render the grouped catalog in both the plain (\`NO_COLOR=1\` / non-TTY) and colored tree-pipe layouts used by \`usage()\` and \`printToolLogsSummary()\`; add a QUICKSTART section to both surfaces.
- \`package.json\` / \`package-lock.json\`: bump \`@imdeadpool/guardex\` from \`7.0.27\` → \`7.0.28\` so the CLI UX change can publish on a fresh npm version.
- \`README.md\`: add a \`### v7.0.28\` release note (the metadata test requires a matching heading to exist for the current package version).

## Test plan

- [x] \`node --test test/metadata.test.js test/output.test.js test/cli-args-dispatch.test.js\` — 35 pass, 0 new failures.
- [x] \`NO_COLOR=1 node bin/multiagent-safety.js --help\` — plain help renders the new QUICKSTART + grouped COMMANDS sections.
- [x] \`FORCE_COLOR=1 node bin/multiagent-safety.js\` — no-args output renders the same groups inside the existing tree-pipe layout with colored group headers.
- [ ] Publish to npm (\`npm publish\`) once merged; \`7.0.28\` is still unpublished.

## Known unrelated failures

- \`critical runtime helper scripts and active-agents sources stay in sync with templates\` / \`setup provisions workflow files and repo config\` — both are pre-existing on \`main\` (verified via \`git stash\` + rerun); caused by \`vscode/guardex-active-agents/extension.js\` drifting from its template. Not touched in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)