### PR TITLE
fix(branch-finish): rephrase pending-PR cleanup message so claude doesn't claim the worktree is on disk

### DIFF
--- a/scripts/agent-branch-finish.sh
+++ b/scripts/agent-branch-finish.sh
@@ -831,7 +831,7 @@ if [[ "$PUSH_ENABLED" -eq 1 ]]; then
           echo "[agent-branch-finish] Merge did not complete within wait window; keeping branch open." >&2
           exit 1
         fi
-        echo "[agent-branch-finish] Merge pending review/check policy. Branch cleanup skipped for now." >&2
+        echo "[agent-branch-finish] PR pending review/check policy. Worktree retained for now; the autofinish watcher (or 'gx worktree prune --include-pr-merged --delete-branches') will prune it after merge. Verify with 'git worktree list' before claiming the worktree is still on disk." >&2
         exit 0
       fi
       echo "[agent-branch-finish] PR flow failed." >&2

--- a/src/doctor/index.js
+++ b/src/doctor/index.js
@@ -310,7 +310,7 @@ function extractAgentBranchFinishPrUrl(output) {
 function doctorFinishFlowIsPending(output) {
   return (
     /\[agent-branch-finish\] PR merge not completed yet; leaving PR open\./.test(output) ||
-    /\[agent-branch-finish\] Merge pending review\/check policy\. Branch cleanup skipped for now\./.test(output) ||
+    /\[agent-branch-finish\] PR pending review\/check policy\./.test(output) ||
     /\[agent-branch-finish\] PR auto-merge enabled; waiting for required checks\/reviews\./.test(output)
   );
 }

--- a/templates/scripts/agent-branch-finish.sh
+++ b/templates/scripts/agent-branch-finish.sh
@@ -831,7 +831,7 @@ if [[ "$PUSH_ENABLED" -eq 1 ]]; then
           echo "[agent-branch-finish] Merge did not complete within wait window; keeping branch open." >&2
           exit 1
         fi
-        echo "[agent-branch-finish] Merge pending review/check policy. Branch cleanup skipped for now." >&2
+        echo "[agent-branch-finish] PR pending review/check policy. Worktree retained for now; the autofinish watcher (or 'gx worktree prune --include-pr-merged --delete-branches') will prune it after merge. Verify with 'git worktree list' before claiming the worktree is still on disk." >&2
         exit 0
       fi
       echo "[agent-branch-finish] PR flow failed." >&2


### PR DESCRIPTION
Automated by gx branch finish (PR flow).