### PR TITLE
Release Guardex v7.0.42

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,18 @@ Being honest about where this still has issues:
 <details open>
 <summary><strong>v7.x</strong></summary>
 
+### v7.0.42
+- Bumped `@imdeadpool/guardex` from `7.0.41` to `7.0.42` so the current
+  `main` payload can publish under a fresh npm version after `7.0.41` reached
+  the registry.
+- Improves the agent-session and cockpit workflow: `gx agents start/status`
+  now share canonical session storage, agent lanes can be previewed, claimed,
+  finished by session, and launched through safer supported-agent metadata,
+  and cockpit can render live session state through tmux-backed panes.
+- Hardens setup and status hygiene by ignoring local `.codex/` state during
+  setup/doctor, avoiding generic OpenSpec dirty-worktree reuse, and pruning
+  stale agent sessions from user-facing status surfaces.
+
 ### v7.0.41
 - Bumped `@imdeadpool/guardex` from `7.0.40` to `7.0.41` so the current
   `main` payload can publish under a fresh npm version after the `v7.0.40`

--- a/openspec/changes/agent-codex-bump-npm-version-7-0-42-release-2026-04-29-22-36/.openspec.yaml
+++ b/openspec/changes/agent-codex-bump-npm-version-7-0-42-release-2026-04-29-22-36/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/agent-codex-bump-npm-version-7-0-42-release-2026-04-29-22-36/notes.md
+++ b/openspec/changes/agent-codex-bump-npm-version-7-0-42-release-2026-04-29-22-36/notes.md
@@ -1,0 +1,36 @@
+# agent-codex-bump-npm-version-7-0-42-release-2026-04-29-22-36 (minimal / T1)
+
+Branch: `agent/codex/bump-npm-version-7-0-42-release-2026-04-29-22-36`
+
+Bump `@imdeadpool/guardex` to `7.0.42` and cut a matching GitHub release so
+the merged Guardex changes after `v7.0.41` have a fresh npm package version.
+
+Scope:
+- Bump `package.json` and `package-lock.json` from `7.0.41` to `7.0.42`.
+- Add a `README.md` release note for `v7.0.42` covering PRs `#451` through
+  `#473`.
+- Verify package metadata and tarball contents before finish.
+
+Verification:
+- `node --check bin/multiagent-safety.js`
+- `npm pack --dry-run`
+- `openspec validate --specs`
+- `git diff --check`
+- `npm test` when the current baseline allows it
+
+Known baseline:
+- Full `npm test` was red before this release edit on unrelated agent launch,
+  agent session, and CLI args assertions. Keep release verification scoped to
+  metadata, release notes, and package tarball unless those baseline failures
+  are fixed separately.
+
+## Handoff
+
+- Handoff: change=`agent-codex-bump-npm-version-7-0-42-release-2026-04-29-22-36`; branch=`agent/codex/bump-npm-version-7-0-42-release-2026-04-29-22-36`; scope=`package.json, package-lock.json, README.md, openspec/changes/agent-codex-bump-npm-version-7-0-42-release-2026-04-29-22-36/*`; action=`finish this sandbox via PR merge + cleanup after targeted verification`.
+- Copy prompt: Continue `agent-codex-bump-npm-version-7-0-42-release-2026-04-29-22-36` on branch `agent/codex/bump-npm-version-7-0-42-release-2026-04-29-22-36`. Work inside the existing sandbox, review `openspec/changes/agent-codex-bump-npm-version-7-0-42-release-2026-04-29-22-36/notes.md`, continue from the current state instead of creating a new sandbox, and when the work is done run `gx branch finish --branch agent/codex/bump-npm-version-7-0-42-release-2026-04-29-22-36 --base main --via-pr --wait-for-merge --cleanup`.
+
+## Cleanup
+
+- [ ] Run: `gx branch finish --branch agent/codex/bump-npm-version-7-0-42-release-2026-04-29-22-36 --base main --via-pr --wait-for-merge --cleanup`
+- [ ] Record PR URL + `MERGED` state in the completion handoff.
+- [ ] Confirm sandbox worktree is gone (`git worktree list`, `git branch -a`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "7.0.41",
+  "version": "7.0.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@imdeadpool/guardex",
-      "version": "7.0.41",
+      "version": "7.0.42",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "7.0.41",
+  "version": "7.0.42",
   "description": "Guardian T-Rex for your multi-agent repo. Isolated worktrees, file locks, and PR-only merges stop parallel Codex & Claude agents from overwriting each other's work. Auto-wires Oh My Codex, Oh My Claude, OpenSpec, and Caveman.",
   "license": "MIT",
   "preferGlobal": true,


### PR DESCRIPTION
## Summary
- bump @imdeadpool/guardex from 7.0.41 to 7.0.42
- add README release notes for PRs #451 through #473
- add T1 OpenSpec release notes for the version lane

## Verification
- PASS: npm view @imdeadpool/guardex version -> 7.0.41
- PASS: gh release view v7.0.41
- PASS: node --test test/metadata.test.js
- PASS: node --check bin/multiagent-safety.js
- PASS: npm pack --dry-run
- PASS: openspec validate --specs
- PASS: git diff --check
- NOT RUN: full npm test, because the current baseline is known red outside this release metadata lane

## Release note
After merge, create GitHub release v7.0.42 and verify npm publish advances from 7.0.41 to 7.0.42.