### PR TITLE
Add tmux pane primitives

### DIFF
--- a/src/tmux/panes.js
+++ b/src/tmux/panes.js
@@ -1,0 +1,181 @@
+const tmux = require('./command');
+
+const PANE_FIELD_SEPARATOR = '\x1f';
+const PANE_FORMAT = [
+  '#{pane_id}',
+  '#{session_name}',
+  '#{window_index}',
+  '#{pane_index}',
+  '#{pane_title}',
+  '#{pane_current_command}',
+  '#{pane_active}',
+].join(PANE_FIELD_SEPARATOR);
+
+function requireText(value, label) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new TypeError(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function addCwd(args, cwd) {
+  if (cwd !== undefined) {
+    args.push('-c', requireText(cwd, 'tmux cwd'));
+  }
+}
+
+function addCommand(args, command) {
+  if (command !== undefined) {
+    args.push(requireCommand(command));
+  }
+}
+
+function requireCommand(command) {
+  if (typeof command !== 'string') {
+    throw new TypeError('tmux command must be a string');
+  }
+  return command;
+}
+
+function requirePositiveInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new TypeError(`${label} must be a positive integer`);
+  }
+  return String(parsed);
+}
+
+function parsePane(line) {
+  const [
+    paneId,
+    sessionName,
+    windowIndex,
+    paneIndex,
+    title,
+    currentCommand,
+    active,
+  ] = line.split(PANE_FIELD_SEPARATOR);
+
+  return {
+    id: paneId,
+    sessionName,
+    windowIndex: Number.parseInt(windowIndex, 10),
+    paneIndex: Number.parseInt(paneIndex, 10),
+    title,
+    currentCommand,
+    active: active === '1',
+  };
+}
+
+function listPanes(sessionName) {
+  const result = tmux.runTmux(
+    ['list-panes', '-s', '-t', requireText(sessionName, 'tmux session name'), '-F', PANE_FORMAT],
+    { stdio: 'pipe' },
+  );
+  if (result.status !== 0 || !result.stdout.trim()) {
+    return [];
+  }
+  return result.stdout.trim().split('\n').map(parsePane);
+}
+
+function splitPane(targetPane, options = {}) {
+  const direction = options.direction || options.split || 'vertical';
+  const args = ['split-window'];
+
+  if (direction === 'horizontal') {
+    args.push('-h');
+  } else if (direction === 'vertical') {
+    args.push('-v');
+  } else {
+    throw new TypeError('tmux split direction must be horizontal or vertical');
+  }
+
+  args.push('-t', requireText(targetPane, 'tmux pane target'));
+
+  if (options.detached === true) {
+    args.push('-d');
+  }
+  if (options.size !== undefined) {
+    args.push('-l', requirePositiveInteger(options.size, 'tmux split size'));
+  }
+  addCwd(args, options.cwd);
+  addCommand(args, options.command);
+  return tmux.runTmux(args);
+}
+
+function selectLayout(sessionName, layoutName) {
+  return tmux.runTmux([
+    'select-layout',
+    '-t',
+    requireText(sessionName, 'tmux session name'),
+    requireText(layoutName, 'tmux layout name'),
+  ]);
+}
+
+function resizePane(targetPane, options = {}) {
+  const args = ['resize-pane', '-t', requireText(targetPane, 'tmux pane target')];
+  const directionFlags = {
+    left: '-L',
+    right: '-R',
+    up: '-U',
+    down: '-D',
+  };
+
+  if (options.direction !== undefined) {
+    const flag = directionFlags[options.direction];
+    if (!flag) {
+      throw new TypeError('tmux resize direction must be left, right, up, or down');
+    }
+    args.push(flag);
+    if (options.cells !== undefined) {
+      args.push(requirePositiveInteger(options.cells, 'tmux resize cells'));
+    }
+  }
+
+  if (options.width !== undefined) {
+    args.push('-x', requirePositiveInteger(options.width, 'tmux pane width'));
+  }
+  if (options.height !== undefined) {
+    args.push('-y', requirePositiveInteger(options.height, 'tmux pane height'));
+  }
+
+  if (args.length === 3) {
+    throw new TypeError('tmux resize requires direction, width, or height');
+  }
+
+  return tmux.runTmux(args);
+}
+
+function sendCommand(targetPane, command) {
+  return tmux.runTmux([
+    'send-keys',
+    '-t',
+    requireText(targetPane, 'tmux pane target'),
+    requireCommand(command),
+    'C-m',
+  ]);
+}
+
+function killPane(targetPane) {
+  return tmux.runTmux(['kill-pane', '-t', requireText(targetPane, 'tmux pane target')]);
+}
+
+function setPaneTitle(targetPane, title) {
+  return tmux.runTmux([
+    'select-pane',
+    '-t',
+    requireText(targetPane, 'tmux pane target'),
+    '-T',
+    requireText(title, 'tmux pane title'),
+  ]);
+}
+
+module.exports = {
+  listPanes,
+  splitPane,
+  selectLayout,
+  resizePane,
+  sendCommand,
+  killPane,
+  setPaneTitle,
+};

--- a/test/tmux-panes.test.js
+++ b/test/tmux-panes.test.js
@@ -1,0 +1,141 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const panes = require('../src/tmux/panes');
+
+function fakeTmux(scriptBody) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'guardex-fake-tmux-panes-'));
+  const bin = path.join(dir, 'tmux');
+  const log = path.join(dir, 'tmux.log');
+  fs.writeFileSync(
+    bin,
+    [
+      '#!/usr/bin/env node',
+      "const fs = require('node:fs');",
+      'const args = process.argv.slice(2);',
+      `fs.appendFileSync(${JSON.stringify(log)}, JSON.stringify(args) + '\\n');`,
+      scriptBody,
+    ].join('\n'),
+    'utf8',
+  );
+  fs.chmodSync(bin, 0o755);
+  return { bin, log };
+}
+
+function withFakeTmux(scriptBody, callback) {
+  const originalTmuxBin = process.env.GUARDEX_TMUX_BIN;
+  const fake = fakeTmux(scriptBody);
+  process.env.GUARDEX_TMUX_BIN = fake.bin;
+
+  try {
+    callback(fake);
+  } finally {
+    if (originalTmuxBin === undefined) {
+      delete process.env.GUARDEX_TMUX_BIN;
+    } else {
+      process.env.GUARDEX_TMUX_BIN = originalTmuxBin;
+    }
+  }
+}
+
+function readCalls(log) {
+  return fs.readFileSync(log, 'utf8').trim().split('\n').map((line) => JSON.parse(line));
+}
+
+test('listPanes reads a session through GUARDEX_TMUX_BIN and parses panes', () => {
+  withFakeTmux(
+    [
+      "if (args[0] !== 'list-panes') process.exit(9);",
+      "const separator = '\\x1f';",
+      "console.log(['%1', 'guardex', '0', '0', 'control', 'node', '1'].join(separator));",
+      "console.log(['%2', 'guardex', '0', '1', 'worker', 'bash', '0'].join(separator));",
+    ].join('\n'),
+    ({ log }) => {
+      assert.deepEqual(panes.listPanes('guardex'), [
+        {
+          id: '%1',
+          sessionName: 'guardex',
+          windowIndex: 0,
+          paneIndex: 0,
+          title: 'control',
+          currentCommand: 'node',
+          active: true,
+        },
+        {
+          id: '%2',
+          sessionName: 'guardex',
+          windowIndex: 0,
+          paneIndex: 1,
+          title: 'worker',
+          currentCommand: 'bash',
+          active: false,
+        },
+      ]);
+
+      const [call] = readCalls(log);
+      assert.deepEqual(call.slice(0, 5), ['list-panes', '-s', '-t', 'guardex', '-F']);
+      assert.match(call[5], /#\{pane_id\}/);
+      assert.match(call[5], /#\{pane_active\}/);
+    },
+  );
+});
+
+test('splitPane and selectLayout use argv arrays without shell expansion', () => {
+  withFakeTmux('process.exit(0);', ({ log }) => {
+    panes.splitPane('%1', {
+      direction: 'horizontal',
+      cwd: '/repo path',
+      size: 30,
+      command: 'gx agents status; echo literal',
+    });
+    panes.selectLayout('guardex', 'tiled');
+
+    assert.deepEqual(readCalls(log), [
+      [
+        'split-window',
+        '-h',
+        '-t',
+        '%1',
+        '-l',
+        '30',
+        '-c',
+        '/repo path',
+        'gx agents status; echo literal',
+      ],
+      ['select-layout', '-t', 'guardex', 'tiled'],
+    ]);
+  });
+});
+
+test('pane commands target panes with tmux argv primitives', () => {
+  withFakeTmux('process.exit(0);', ({ log }) => {
+    panes.resizePane('%2', { direction: 'left', cells: 5 });
+    panes.resizePane('%2', { width: 120, height: 40 });
+    panes.sendCommand('%2', 'npm test && echo literal');
+    panes.killPane('%3');
+    panes.setPaneTitle('%2', 'status pane');
+
+    assert.deepEqual(readCalls(log), [
+      ['resize-pane', '-t', '%2', '-L', '5'],
+      ['resize-pane', '-t', '%2', '-x', '120', '-y', '40'],
+      ['send-keys', '-t', '%2', 'npm test && echo literal', 'C-m'],
+      ['kill-pane', '-t', '%3'],
+      ['select-pane', '-t', '%2', '-T', 'status pane'],
+    ]);
+  });
+});
+
+test('pane primitives reject invalid values before calling tmux', () => {
+  assert.throws(() => panes.listPanes(''), /tmux session name/);
+  assert.throws(() => panes.splitPane('', {}), /tmux pane target/);
+  assert.throws(() => panes.splitPane('%1', { direction: 'diagonal' }), /horizontal or vertical/);
+  assert.throws(() => panes.resizePane('%1', {}), /requires direction/);
+  assert.throws(() => panes.resizePane('%1', { direction: 'sideways' }), /left, right, up, or down/);
+  assert.throws(() => panes.resizePane('%1', { width: 0 }), /positive integer/);
+  assert.throws(() => panes.sendCommand('%1', 42), /tmux command/);
+  assert.throws(() => panes.killPane(''), /tmux pane target/);
+  assert.throws(() => panes.setPaneTitle('%1', ''), /tmux pane title/);
+});


### PR DESCRIPTION
Summary: Adds src/tmux/panes.js primitives for listing, splitting, layout selection, resizing, sending commands, killing panes, and setting pane titles through argv-based runTmux. Adds fake tmux binary coverage in test/tmux-panes.test.js. Scope: no gx cockpit behavior is wired yet. Verification: PASS node --test test/tmux-panes.test.js test/tmux-session.test.js test/tmux-command.test.js. PARTIAL npm test exited 1 after 380 tests; new tmux-panes tests passed, with unrelated baseline failures in test/agents-launch.test.js and test/agents-sessions.test.js.