### PR TITLE
fix(agent-branch-start): verify worktree exists before printing Ready:

### DIFF
--- a/templates/scripts/agent-branch-start.sh
+++ b/templates/scripts/agent-branch-start.sh
@@ -417,6 +417,20 @@ print_agent_next_steps() {
     base_branch="main"
   fi
 
+  # Pre-`Ready:` post-condition check. `git worktree add` has been observed
+  # to return 0 with the worktree dir still missing on disk (race condition
+  # during the OpenSpec / dependency-symlink phase between `worktree add`
+  # and now). If we print `Ready:` in that state, callers cd into a
+  # vanished directory and lose subsequent edits silently. Surface it as
+  # an exit-1 error instead — operator can retry + `git worktree prune`.
+  if [[ ! -d "$worktree_path" || ! -e "$worktree_path/.git" ]]; then
+    printf '[agent-branch-start] ERROR: worktree did not materialize on disk before Ready:\n' >&2
+    printf '[agent-branch-start]   branch:   %s\n' "$branch_name" >&2
+    printf '[agent-branch-start]   expected: %s\n' "$worktree_path" >&2
+    printf '[agent-branch-start] Run `git worktree prune` to clear ghost entries, then retry.\n' >&2
+    exit 1
+  fi
+
   echo "[agent-branch-start] Ready:"
   echo "  branch:   ${branch_name}"
   echo "  worktree: ${worktree_path}"
@@ -861,6 +875,13 @@ fi
 
 worktree_add_output=""
 if ! worktree_add_output="$(git -C "$repo_root" worktree add -b "$branch_name" "$worktree_path" "$start_ref" 2>&1)"; then
+  printf '%s\n' "$worktree_add_output" >&2
+  exit 1
+fi
+# git worktree add has been observed to exit 0 while the target dir is
+# missing — verify before downstream init runs against a phantom path.
+if [[ ! -d "$worktree_path" || ! -e "$worktree_path/.git" ]]; then
+  printf '[agent-branch-start] ERROR: git worktree add reported success but %s is not a valid worktree.\n' "$worktree_path" >&2
   printf '%s\n' "$worktree_add_output" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

`git worktree add` has been observed (twice in one Claude session on a downstream consumer of this template) to return exit code 0 with the target directory missing on disk. The script then ran OpenSpec / dependency-symlink init against the phantom path, eventually printing \`[agent-branch-start] Ready:\` and returning success. Callers cd into the vanished directory, claim file locks against it, and silently lose every subsequent edit until \`gx branch finish\` later complains about a missing tree.

## Changes

Two defensive checks in `templates/scripts/agent-branch-start.sh`:

1. Immediately after `git worktree add` returns 0 — fail fast before the init phase runs against a phantom path.
2. At the top of `print_agent_next_steps` — covers the case where the dir disappears during init (rare, but cheap to verify).

Both report the branch name + expected path and instruct the operator to run \`git worktree prune\` before retry.

## Test plan

- [x] Shellcheck via \`bash -n\` passes.
- [ ] Run \`gx branch start --tier T0 "test verify" "claude"\` on a clean repo — verify normal happy path still works.
- [ ] Force the failure mode (e.g. \`mkdir -p\` race or manually removing the worktree dir between \`worktree add\` and the verify) — confirm exit 1 with the expected error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)