### PR TITLE
feat(speckit): add gx speckit subcommand to install Spec Kit + prune scaffold

### DIFF
--- a/openspec/changes/agent-claude-gx-setup-installs-speckit-2026-05-17-00-10/.openspec.yaml
+++ b/openspec/changes/agent-claude-gx-setup-installs-speckit-2026-05-17-00-10/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/agent-claude-gx-setup-installs-speckit-2026-05-17-00-10/proposal.md
+++ b/openspec/changes/agent-claude-gx-setup-installs-speckit-2026-05-17-00-10/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+- Operators currently have to run `specify init --here --ai claude --force --ignore-agent-tools` by hand after every `gx setup` to wire Spec Kit's SDD slash skills into a repo, then manually delete the heavy auto-generated `openspec/plan/agent-…-masterplan-setup-spec-kit-…/` and `openspec/changes/agent-…-setup-spec-kit-…/specs/` scaffolds. Bake this into gx so one command does it cleanly.
+
+## What Changes
+
+- New `src/speckit/index.js` module exposing `runSpeckitCommand(rawArgs)`, `installSpeckit({ target, dryRun, prune })`, and helpers.
+- New `gx speckit` subcommand wired into `src/cli/main.js` dispatch.
+- New CLI catalog entry in `src/context.js` (both the flat `CLI_COMMAND_DESCRIPTIONS` list and the grouped `CLI_COMMAND_GROUPS` "Agents & reports" section).
+- `gx speckit` flow:
+  1. Probes `specify` on `PATH`; prints install hint and exits if missing.
+  2. Runs `specify init --here --ai claude --force --ignore-agent-tools` in the target repo.
+  3. Prunes auto-created `openspec/plan/agent-…-masterplan-setup-spec-kit-…/` and `openspec/changes/agent-…-setup-spec-kit-…/specs/` scaffolds (toggle via `--no-prune`).
+  4. Prints next-steps mentioning `gx pivot` for the agent-worktree flow (kept unchanged).
+- Supported flags: `--target <path>`, `--no-prune`, `--prune`, `--dry-run`, `-h/--help`.
+
+## Impact
+
+- Existing `gx setup`, `gx pivot`, `gx finish`, and `gx cleanup` behavior is unchanged — speckit install is a separate opt-in subcommand.
+- No new runtime dependencies; `specify` is invoked only when present on `PATH`.
+- New module is isolated under `src/speckit/`; only two trivial dispatch wiring edits in `src/cli/main.js` and two catalog entries in `src/context.js`.
+- The 23 pre-existing test failures in `branch.test.js`, `cockpit-*.test.js`, and `welcome.test.js` are unrelated to this change.

--- a/openspec/changes/agent-claude-gx-setup-installs-speckit-2026-05-17-00-10/tasks.md
+++ b/openspec/changes/agent-claude-gx-setup-installs-speckit-2026-05-17-00-10/tasks.md
@@ -1,0 +1,23 @@
+## Definition of Done
+
+- Branch `MERGED` on `origin`, PR URL captured.
+
+## 1. Implementation
+
+- [x] 1.1 Add `src/speckit/index.js` (subcommand module + `installSpeckit` helper).
+- [x] 1.2 Wire `gx speckit` into `src/cli/main.js` dispatch via `lazyProxy`.
+- [x] 1.3 Add `speckit` to `CLI_COMMAND_DESCRIPTIONS` + the "Agents & reports" group in `src/context.js`.
+
+## 2. Smoke
+
+- [x] 2.1 `node bin/multiagent-safety.js speckit --help` prints the new help.
+- [x] 2.2 `node bin/multiagent-safety.js --help` shows `speckit` in the catalog.
+- [x] 2.3 `node bin/multiagent-safety.js speckit --dry-run` (in a tmp git repo) detects the system `specify` binary, prints what it would do, and exits 0.
+- [x] 2.4 `node --check src/speckit/index.js src/cli/main.js src/context.js` clean.
+- [x] 2.5 `node --test test/*.test.js` → 539 pass / 23 fail (failures all pre-existing in branch / cockpit / welcome tests; none touch speckit).
+
+## 3. Ship
+
+- [ ] 3.1 Commit + push + PR vs `main` + squash auto-merge.
+- [ ] 3.2 Record PR URL + `MERGED` state.
+- [ ] 3.3 Confirm sandbox worktree pruned post-merge.

--- a/src/cli/main.js
+++ b/src/cli/main.js
@@ -37,6 +37,7 @@ const finishAgentSession = (...callArgs) => agentsFinishModule.finishAgentSessio
 const sessionSeverityReport = lazyProxy(() => require('../report/session-severity'));
 const budgetModule = lazyProxy(() => require('../budget'));
 const ciInitModule = lazyProxy(() => require('../ci-init'));
+const speckitModule = lazyProxy(() => require('../speckit'));
 const cockpitModule = lazyProxy(() => require('../cockpit'));
 const agentsStart = lazyProxy(() => require('../agents/start'));
 const prReviewModule = lazyProxy(() => require('../pr-review'));
@@ -3919,6 +3920,7 @@ async function main() {
   if (command === 'release') return release(rest);
   if (command === 'budget') return budgetModule.runBudgetCommand(rest);
   if (command === 'ci-init') return ciInitModule.runCiInitCommand(rest);
+  if (command === 'speckit') return speckitModule.runSpeckitCommand(rest);
 
   const suggestion = maybeSuggestCommand(command);
   if (suggestion) {

--- a/src/context.js
+++ b/src/context.js
@@ -380,6 +380,7 @@ const SUGGESTIBLE_COMMANDS = [
   'release',
   'budget',
   'ci-init',
+  'speckit',
 ];
 // CLI_COMMAND_GROUPS is the grouped source of truth the `gx --help` /
 // `gx` no-args renderer uses. Each group is ordered roughly by how often a
@@ -428,6 +429,7 @@ const CLI_COMMAND_GROUPS = [
       ['pr-review', 'Run local Codex/Claude PR review and post inline GitHub comments or write an artifact'],
       ['cockpit', 'Create or attach to a repo tmux cockpit session'],
       ['install-agent-skills', 'Install Guardex Codex/Claude skills into the user home'],
+      ['speckit', 'Install Spec Kit (specify-cli) SDD slash skills (/speckit-specify, /speckit-plan, ...) into the current repo'],
       ['prompt', 'Print AI setup checklist or named slices (--exec, --part, --list-parts, --snippet)'],
       ['report', 'Security/safety reports (e.g. OpenSSF scorecard, session severity)'],
       ['release', 'Create or update the current GitHub release with README-generated notes'],

--- a/src/speckit/index.js
+++ b/src/speckit/index.js
@@ -1,0 +1,196 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const cp = require('node:child_process');
+
+const { TOOL_NAME, SHORT_TOOL_NAME } = require('../context');
+
+const SPECIFY_BIN = 'specify';
+const SPECKIT_INSTALL_HINT =
+  'uv tool install specify-cli --from git+https://github.com/github/spec-kit.git';
+
+function whichSpecify() {
+  const result = cp.spawnSync(process.platform === 'win32' ? 'where' : 'which', [SPECIFY_BIN], {
+    encoding: 'utf8',
+  });
+  if (result.status === 0 && result.stdout && result.stdout.trim()) {
+    return result.stdout.trim().split(/\r?\n/)[0];
+  }
+  return null;
+}
+
+function specifyVersion(specifyPath) {
+  const result = cp.spawnSync(specifyPath, ['--version'], { encoding: 'utf8' });
+  if (result.status === 0 && result.stdout) {
+    return result.stdout.trim();
+  }
+  return null;
+}
+
+function isGitRepo(target) {
+  try {
+    const result = cp.spawnSync('git', ['-C', target, 'rev-parse', '--git-dir'], {
+      encoding: 'utf8',
+    });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+function listSpecKitOpenSpecScaffolds(target) {
+  const planRoot = path.join(target, 'openspec', 'plan');
+  const changesRoot = path.join(target, 'openspec', 'changes');
+  const result = { planDirs: [], specsDirs: [] };
+  if (fs.existsSync(planRoot) && fs.statSync(planRoot).isDirectory()) {
+    for (const entry of fs.readdirSync(planRoot)) {
+      if (/^agent-.*-masterplan-setup-spec-kit-/i.test(entry)) {
+        result.planDirs.push(path.join(planRoot, entry));
+      }
+    }
+  }
+  if (fs.existsSync(changesRoot) && fs.statSync(changesRoot).isDirectory()) {
+    for (const entry of fs.readdirSync(changesRoot)) {
+      if (/^agent-.*-setup-spec-kit-/i.test(entry)) {
+        const specsDir = path.join(changesRoot, entry, 'specs');
+        if (fs.existsSync(specsDir)) result.specsDirs.push(specsDir);
+      }
+    }
+  }
+  return result;
+}
+
+function pruneSpecKitScaffolds(target, { dryRun, logger }) {
+  const found = listSpecKitOpenSpecScaffolds(target);
+  const removed = [];
+  for (const dir of [...found.planDirs, ...found.specsDirs]) {
+    if (dryRun) {
+      logger(`[${TOOL_NAME}] dry-run: would prune ${path.relative(target, dir)}`);
+    } else {
+      fs.rmSync(dir, { recursive: true, force: true });
+      logger(`[${TOOL_NAME}] pruned ${path.relative(target, dir)}`);
+    }
+    removed.push(dir);
+  }
+  return removed;
+}
+
+function runSpecifyInit(target, { dryRun, logger }) {
+  const args = ['init', '--here', '--ai', 'claude', '--force', '--ignore-agent-tools'];
+  if (dryRun) {
+    logger(`[${TOOL_NAME}] dry-run: would run \`${SPECIFY_BIN} ${args.join(' ')}\` in ${target}`);
+    return { status: 'dry-run' };
+  }
+  const result = cp.spawnSync(SPECIFY_BIN, args, {
+    cwd: target,
+    stdio: 'inherit',
+  });
+  if (result.status !== 0) {
+    throw new Error(`${SPECIFY_BIN} init exited with status ${result.status}`);
+  }
+  return { status: 'ok' };
+}
+
+function installSpeckit({ target = process.cwd(), dryRun = false, prune = true, logger = console.log }) {
+  const resolved = path.resolve(target);
+  if (!fs.existsSync(resolved) || !fs.statSync(resolved).isDirectory()) {
+    throw new Error(`Target directory does not exist: ${resolved}`);
+  }
+  if (!isGitRepo(resolved)) {
+    logger(
+      `[${TOOL_NAME}] ⚠️ ${resolved} is not a git repo. Spec Kit will scaffold without git extension wiring.`,
+    );
+  }
+  const specifyPath = whichSpecify();
+  if (!specifyPath) {
+    throw new Error(
+      `${SPECIFY_BIN} CLI not found on PATH. Install with:\n  ${SPECKIT_INSTALL_HINT}`,
+    );
+  }
+  const version = specifyVersion(specifyPath);
+  logger(`[${TOOL_NAME}] specify-cli: ${specifyPath}${version ? ` (${version})` : ''}`);
+  logger(`[${TOOL_NAME}] Running \`${SPECIFY_BIN} init --here --ai claude --force\` in ${resolved}`);
+
+  const initResult = runSpecifyInit(resolved, { dryRun, logger });
+
+  let pruned = [];
+  if (prune && initResult.status === 'ok') {
+    pruned = pruneSpecKitScaffolds(resolved, { dryRun, logger });
+  } else if (prune && dryRun) {
+    pruned = pruneSpecKitScaffolds(resolved, { dryRun, logger });
+  }
+
+  logger('');
+  logger(`[${TOOL_NAME}] ✅ Spec Kit installed. Next:`);
+  logger(`  - Start a fresh Claude session at ${resolved}`);
+  logger(`  - Use slash skills: /speckit-constitution, /speckit-specify, /speckit-plan, /speckit-tasks, /speckit-implement`);
+  logger(`  - Agent worktree flow is unchanged — run \`${SHORT_TOOL_NAME} pivot "<task>" "claude"\` to start work.`);
+
+  return { specifyPath, version, dryRun, prunedScaffolds: pruned };
+}
+
+function printSpeckitHelp() {
+  const lines = [
+    `Usage: ${SHORT_TOOL_NAME} speckit [options]`,
+    '',
+    '  Install Spec Kit (specify-cli) SDD slash skills into the current repo.',
+    '  Runs `specify init --here --ai claude --force --ignore-agent-tools` and',
+    '  prunes the heavy auto-generated openspec/plan + specs/ scaffolds the',
+    '  specify-cli emits, so it composes cleanly with the existing gx workflow.',
+    '',
+    'Options:',
+    '  --target <path>   Run in <path> instead of cwd',
+    '  --no-prune        Keep the auto-generated openspec/plan + specs scaffolds',
+    '  --dry-run         Print actions without modifying files',
+    '  -h, --help        Show this help',
+    '',
+    'Prerequisite:',
+    `  ${SPECIFY_BIN} CLI on PATH. Install with:`,
+    `    ${SPECKIT_INSTALL_HINT}`,
+  ];
+  console.log(lines.join('\n'));
+}
+
+function runSpeckitCommand(rawArgs) {
+  const args = Array.isArray(rawArgs) ? [...rawArgs] : [];
+  let target = process.cwd();
+  let prune = true;
+  let dryRun = false;
+
+  while (args.length > 0) {
+    const arg = args.shift();
+    if (arg === '-h' || arg === '--help' || arg === 'help') {
+      printSpeckitHelp();
+      return;
+    }
+    if (arg === '--target') {
+      const next = args.shift();
+      if (!next) throw new Error('--target requires a path value');
+      target = next;
+      continue;
+    }
+    if (arg === '--no-prune') {
+      prune = false;
+      continue;
+    }
+    if (arg === '--prune') {
+      prune = true;
+      continue;
+    }
+    if (arg === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  installSpeckit({ target, prune, dryRun });
+}
+
+module.exports = {
+  runSpeckitCommand,
+  installSpeckit,
+  pruneSpecKitScaffolds,
+  whichSpecify,
+};


### PR DESCRIPTION
## Summary

- New `gx speckit` subcommand wires Spec Kit's SDD slash skills (`/speckit-specify`, `/speckit-plan`, `/speckit-tasks`, `/speckit-implement`, etc.) into a repo in one command, on top of the existing gx workflow.
- Composes with the existing surface:
  ```
  gx setup       # gx scaffold + cleanup (unchanged)
  gx speckit     # specify init + prune heavy openspec/plan + specs/ scaffold
  gx pivot ...   # agent worktree (unchanged)
  ```

## What it does

1. Probes `specify` on `PATH`; prints install hint and exits non-zero if missing.
2. Runs `specify init --here --ai claude --force --ignore-agent-tools` in the target repo.
3. Prunes the heavy auto-generated `openspec/plan/agent-…-masterplan-setup-spec-kit-…/` and `openspec/changes/agent-…-setup-spec-kit-…/specs/` scaffolds (same cleanup we'd been doing by hand). `--no-prune` keeps them.
4. Prints next-steps including the `gx pivot` reminder.

Flags: `--target <path>`, `--no-prune`, `--dry-run`, `-h/--help`.

## Files

- `src/speckit/index.js` — new module (`runSpeckitCommand`, `installSpeckit`).
- `src/cli/main.js` — `lazyProxy` import + 1-line dispatch entry.
- `src/context.js` — adds `speckit` to `CLI_COMMAND_DESCRIPTIONS` and the "Agents & reports" group.

## Test plan

- [x] `node --check src/speckit/index.js src/cli/main.js src/context.js` clean.
- [x] `node bin/multiagent-safety.js speckit --help` prints the new help.
- [x] `node bin/multiagent-safety.js --help` shows `speckit` in the catalog.
- [x] `node bin/multiagent-safety.js speckit --dry-run` (in a tmp git repo) detects the system `specify` binary, prints what it would do, exits 0.
- [x] `node --test test/*.test.js` → 539 pass / 23 fail. The 23 failures are pre-existing in `branch.test.js`, `cockpit-*.test.js`, `welcome.test.js`; none touch speckit/dispatch/help.
- [ ] Manual end-to-end on a throwaway repo after merge: `gx setup && gx speckit && gx pivot "test" "claude"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)