### PR TITLE
feat(speckit): run speckit install as part of gx setup by default

### DIFF
--- a/openspec/changes/agent-claude-gx-setup-runs-speckit-by-default-2026-05-17-00-23/.openspec.yaml
+++ b/openspec/changes/agent-claude-gx-setup-runs-speckit-by-default-2026-05-17-00-23/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/agent-claude-gx-setup-runs-speckit-by-default-2026-05-17-00-23/proposal.md
+++ b/openspec/changes/agent-claude-gx-setup-runs-speckit-by-default-2026-05-17-00-23/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+- After PR #588, `gx speckit` was an opt-in subcommand. Operators still had to run two commands (`gx setup && gx speckit`) on every fresh repo to get the SDD slash skills wired in. Make speckit part of the default `gx setup` so one command produces the same setup we'd been doing by hand across recodee / colony / polyagent-cli / gitguardex / codex-fleetui.
+
+## What Changes
+
+- `gx setup` now invokes `speckitModule.installSpeckit` per-repo after `runSetupBootstrapInternal` and before the dry-run early exit, so it runs in both dry-run and real modes.
+- `installSpeckit` gains:
+  - **Idempotency**: short-circuits with `status: 'already-installed'` when `.specify/integration.json` exists, unless `--force/--reinstall` is passed.
+  - **Silent mode**: when called from `gx setup`, missing `specify` on PATH or a missing target degrades to a warning + `status: 'skipped'` instead of throwing — setup never fails because of speckit.
+- New `parseSetupArgs` flags:
+  - `--no-speckit` / `--skip-speckit` — opt out per-invocation.
+  - `--speckit` — explicit opt-in (no-op when default is already on).
+  - `--speckit-force` / `--reinstall-speckit` — re-run `specify init` even when already installed.
+- `--no-global-install` auto-gates speckit too (preserves the existing "minimal setup, no external tooling" semantics relied on by `test/setup.test.js`).
+- `gx speckit` subcommand gains the same `--force` / `--reinstall` flag.
+
+## Impact
+
+- New default repo bootstrap: `gx setup` → gx scaffold + cleanup + speckit install in one command.
+- No behavior change for repos already running `gx speckit` manually (idempotent skip).
+- No new test regressions: full suite still 539 pass / 23 fail (matches PR #588 baseline). `test/setup.test.js` stays 38 pass / 6 fail (the 6 failures are pre-existing).
+- `--no-global-install` (used by `test/setup.test.js`) gates speckit out, preserving the minimal-setup invariants.

--- a/openspec/changes/agent-claude-gx-setup-runs-speckit-by-default-2026-05-17-00-23/tasks.md
+++ b/openspec/changes/agent-claude-gx-setup-runs-speckit-by-default-2026-05-17-00-23/tasks.md
@@ -1,0 +1,26 @@
+## Definition of Done
+
+- Branch `MERGED` on `origin`, PR URL captured.
+
+## 1. Implementation
+
+- [x] 1.1 Add `--no-speckit` / `--speckit` / `--speckit-force` to `parseSetupArgs` in `src/cli/args.js`.
+- [x] 1.2 Wire `speckitModule.installSpeckit` into the per-repo loop in `setup()` in `src/cli/main.js`, before the dry-run early-continue.
+- [x] 1.3 Gate speckit on `!--no-global-install` to preserve "minimal setup, no external tooling" semantics; allow `--speckit-force` to override.
+- [x] 1.4 Add idempotency (`isSpecKitAlreadyInstalled` checks `.specify/integration.json`) and `silent` mode to `installSpeckit` in `src/speckit/index.js`.
+- [x] 1.5 Add `--force` / `--reinstall` to standalone `gx speckit`.
+
+## 2. Smoke
+
+- [x] 2.1 `node --check` clean on main.js / args.js / speckit/index.js.
+- [x] 2.2 Default `gx setup --dry-run` prints speckit install steps.
+- [x] 2.3 `gx setup --dry-run --no-speckit` produces no speckit output.
+- [x] 2.4 `gx setup --dry-run --no-global-install` produces no speckit output (auto-gated).
+- [x] 2.5 Idempotent: `gx setup --dry-run` on a repo with `.specify/integration.json` prints "already installed".
+- [x] 2.6 `node --test test/*.test.js` → 539 pass / 23 fail (matches PR #588 baseline; zero new failures).
+
+## 3. Ship
+
+- [ ] 3.1 Commit + push + PR vs `main` + squash auto-merge.
+- [ ] 3.2 Record PR URL + `MERGED` state.
+- [ ] 3.3 Confirm sandbox worktree pruned post-merge.

--- a/src/cli/args.js
+++ b/src/cli/args.js
@@ -177,6 +177,8 @@ function parseSetupArgs(rawArgs, defaults) {
   const setupDefaults = {
     ...defaults,
     parentWorkspaceView: false,
+    speckit: true,
+    speckitForce: false,
   };
   const forwardedArgs = [];
 
@@ -188,6 +190,19 @@ function parseSetupArgs(rawArgs, defaults) {
     }
     if (arg === '--no-parent-workspace-view') {
       setupDefaults.parentWorkspaceView = false;
+      continue;
+    }
+    if (arg === '--no-speckit' || arg === '--skip-speckit') {
+      setupDefaults.speckit = false;
+      continue;
+    }
+    if (arg === '--speckit') {
+      setupDefaults.speckit = true;
+      continue;
+    }
+    if (arg === '--speckit-force' || arg === '--reinstall-speckit') {
+      setupDefaults.speckit = true;
+      setupDefaults.speckitForce = true;
       continue;
     }
     forwardedArgs.push(arg);

--- a/src/cli/main.js
+++ b/src/cli/main.js
@@ -2960,6 +2960,8 @@ function setup(rawArgs) {
     yesGlobalInstall: false,
     noGlobalInstall: false,
     allowProtectedBaseWrite: false,
+    speckit: true,
+    speckitForce: false,
   });
 
   const globalInstallStatus = toolchainModule.installGlobalToolchain(options);
@@ -3045,6 +3047,34 @@ function setup(rawArgs) {
     const { installPayload, fixPayload, parentWorkspace } = runSetupBootstrapInternal(perRepoOptions);
     printOperations(`Setup/install${repoLabel}`, installPayload, perRepoOptions.dryRun);
     printOperations(`Setup/fix${repoLabel}`, fixPayload, perRepoOptions.dryRun);
+
+    const speckitGloballyDisabled = perRepoOptions.noGlobalInstall === true;
+    if (perRepoOptions.speckit !== false && !speckitGloballyDisabled) {
+      try {
+        speckitModule.installSpeckit({
+          target: repoPath,
+          dryRun: perRepoOptions.dryRun,
+          prune: true,
+          force: perRepoOptions.speckitForce === true,
+          silent: true,
+        });
+      } catch (error) {
+        console.log(`[${TOOL_NAME}] ⚠️ speckit install skipped: ${error.message}`);
+      }
+    } else if (speckitGloballyDisabled && perRepoOptions.speckit === true && perRepoOptions.speckitForce) {
+      // Operator explicitly forced speckit despite --no-global-install — honor that.
+      try {
+        speckitModule.installSpeckit({
+          target: repoPath,
+          dryRun: perRepoOptions.dryRun,
+          prune: true,
+          force: true,
+          silent: true,
+        });
+      } catch (error) {
+        console.log(`[${TOOL_NAME}] ⚠️ speckit install skipped: ${error.message}`);
+      }
+    }
 
     if (perRepoOptions.dryRun) {
       continue;

--- a/src/speckit/index.js
+++ b/src/speckit/index.js
@@ -92,9 +92,24 @@ function runSpecifyInit(target, { dryRun, logger }) {
   return { status: 'ok' };
 }
 
-function installSpeckit({ target = process.cwd(), dryRun = false, prune = true, logger = console.log }) {
+function isSpecKitAlreadyInstalled(target) {
+  return fs.existsSync(path.join(target, '.specify', 'integration.json'));
+}
+
+function installSpeckit({
+  target = process.cwd(),
+  dryRun = false,
+  prune = true,
+  force = false,
+  silent = false,
+  logger = console.log,
+}) {
   const resolved = path.resolve(target);
   if (!fs.existsSync(resolved) || !fs.statSync(resolved).isDirectory()) {
+    if (silent) {
+      logger(`[${TOOL_NAME}] ⚠️ speckit: target ${resolved} does not exist; skipping.`);
+      return { status: 'skipped', reason: 'no-target' };
+    }
     throw new Error(`Target directory does not exist: ${resolved}`);
   }
   if (!isGitRepo(resolved)) {
@@ -102,8 +117,19 @@ function installSpeckit({ target = process.cwd(), dryRun = false, prune = true, 
       `[${TOOL_NAME}] ⚠️ ${resolved} is not a git repo. Spec Kit will scaffold without git extension wiring.`,
     );
   }
+  if (!force && isSpecKitAlreadyInstalled(resolved)) {
+    logger(`[${TOOL_NAME}] ✅ Spec Kit already installed at ${resolved}/.specify (use --speckit-force to reinstall).`);
+    return { status: 'already-installed', target: resolved };
+  }
   const specifyPath = whichSpecify();
   if (!specifyPath) {
+    if (silent) {
+      logger(
+        `[${TOOL_NAME}] ⚠️ speckit: \`${SPECIFY_BIN}\` not on PATH; skipping speckit install. ` +
+        `Install with: ${SPECKIT_INSTALL_HINT}`,
+      );
+      return { status: 'skipped', reason: 'specify-missing' };
+    }
     throw new Error(
       `${SPECIFY_BIN} CLI not found on PATH. Install with:\n  ${SPECKIT_INSTALL_HINT}`,
     );
@@ -115,9 +141,7 @@ function installSpeckit({ target = process.cwd(), dryRun = false, prune = true, 
   const initResult = runSpecifyInit(resolved, { dryRun, logger });
 
   let pruned = [];
-  if (prune && initResult.status === 'ok') {
-    pruned = pruneSpecKitScaffolds(resolved, { dryRun, logger });
-  } else if (prune && dryRun) {
+  if (prune && (initResult.status === 'ok' || dryRun)) {
     pruned = pruneSpecKitScaffolds(resolved, { dryRun, logger });
   }
 
@@ -127,7 +151,7 @@ function installSpeckit({ target = process.cwd(), dryRun = false, prune = true, 
   logger(`  - Use slash skills: /speckit-constitution, /speckit-specify, /speckit-plan, /speckit-tasks, /speckit-implement`);
   logger(`  - Agent worktree flow is unchanged — run \`${SHORT_TOOL_NAME} pivot "<task>" "claude"\` to start work.`);
 
-  return { specifyPath, version, dryRun, prunedScaffolds: pruned };
+  return { status: 'installed', specifyPath, version, dryRun, prunedScaffolds: pruned, target: resolved };
 }
 
 function printSpeckitHelp() {
@@ -157,6 +181,7 @@ function runSpeckitCommand(rawArgs) {
   let target = process.cwd();
   let prune = true;
   let dryRun = false;
+  let force = false;
 
   while (args.length > 0) {
     const arg = args.shift();
@@ -182,10 +207,14 @@ function runSpeckitCommand(rawArgs) {
       dryRun = true;
       continue;
     }
+    if (arg === '--force' || arg === '--reinstall') {
+      force = true;
+      continue;
+    }
     throw new Error(`Unknown option: ${arg}`);
   }
 
-  installSpeckit({ target, prune, dryRun });
+  installSpeckit({ target, prune, dryRun, force });
 }
 
 module.exports = {
@@ -193,4 +222,5 @@ module.exports = {
   installSpeckit,
   pruneSpecKitScaffolds,
   whichSpecify,
+  isSpecKitAlreadyInstalled,
 };


### PR DESCRIPTION
## Summary

Build on #588 by baking speckit install into `gx setup` so one command produces the same setup we'd been doing by hand across recodee / colony / polyagent-cli / gitguardex / codex-fleetui.

## Behavior matrix

| Invocation | gx scaffold | speckit install |
|---|---|---|
| `gx setup` | ✅ | ✅ (default ON) |
| `gx setup --no-speckit` | ✅ | ⏭ skipped |
| `gx setup --no-global-install` | ✅ | ⏭ auto-gated |
| `gx setup --no-global-install --speckit-force` | ✅ | ✅ forced |
| `gx setup --speckit-force` | ✅ | ✅ reinstalls (vs idempotent skip) |

## Changes

- `src/cli/args.js` — `parseSetupArgs` learns `--no-speckit` / `--speckit` / `--speckit-force`.
- `src/cli/main.js` — `setup()` calls `speckitModule.installSpeckit(...)` per-repo (silent mode) right after the bootstrap, before the dry-run continue. Gated on `!--no-global-install`.
- `src/speckit/index.js`:
  - `isSpecKitAlreadyInstalled` checks `.specify/integration.json`. `installSpeckit` short-circuits with `status: 'already-installed'` unless `force` is set.
  - New `silent` mode: missing `specify` or missing target return `status: 'skipped'` instead of throwing.
  - `gx speckit` standalone gains `--force` / `--reinstall`.

## Test plan

- [x] `node --check` clean on `src/cli/main.js`, `src/cli/args.js`, `src/speckit/index.js`.
- [x] Smoke matrix above all behave as expected (verified in a tmp git repo).
- [x] Full test suite: `node --test test/*.test.js` → 539 pass / 23 fail. **Matches the PR #588 baseline exactly — zero new failures.** The 23 failures are all pre-existing in branch / cockpit / welcome / codex-agent / status tests.
- [x] `test/setup.test.js` specifically: 38 pass / 6 fail — same as baseline (the CLAUDE.md-preserve test passes because `--no-global-install` auto-gates speckit).
- [ ] After merge, run on a throwaway repo: `git init test && cd test && gx setup` → speckit installs alongside gx scaffold in one shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)