### PR TITLE
fix(skill_guard): never block edits to files outside the repo working tree

### DIFF
--- a/.claude/hooks/skill_guard.py
+++ b/.claude/hooks/skill_guard.py
@@ -160,6 +160,33 @@ def resolve_repo_root(file_path: str, cwd: str) -> Path:
     return Path.cwd()
 
 
+def path_within_repo(target: str, repo_root: Path, cwd: str) -> bool:
+    """True when `target` resolves to a path inside the guarded repo working tree.
+
+    The edit guard exists to protect the repo's checkout. A write to a file that
+    is NOT inside the repo (e.g. `~/.claude/.../memory/*.md`, `/tmp` scratch)
+    cannot touch the protected branch, so it must never be blocked — even when
+    the current cwd's repo happens to be on a protected branch. Relative targets
+    resolve against the session cwd (which is inside the repo); absolute targets
+    outside the repo return False. Both sides are `.resolve()`d, so `..` and
+    symlinks are canonicalized before the containment check — a symlink inside
+    the repo that points OUT (e.g. `<repo>/link -> /etc`) is intentionally
+    treated as out-of-repo, since the write lands outside the protected tree.
+    """
+    if not target:
+        return False
+    try:
+        candidate = Path(target).expanduser()
+        if not candidate.is_absolute():
+            base = Path(cwd) if cwd else repo_root
+            candidate = base / candidate
+        candidate = candidate.resolve()
+        candidate.relative_to(Path(repo_root).resolve())
+        return True
+    except (ValueError, OSError):
+        return False
+
+
 def normalize_guardex_toggle(raw: str | None) -> bool | None:
     if raw is None:
         return None
@@ -645,6 +672,14 @@ def main() -> None:
     if not target_paths:
         sys.exit(0)
 
+    # Only files inside the guarded repo's working tree are subject to the edit
+    # guard. Writes to paths outside the repo (memory files under ~/.claude,
+    # /tmp scratch, etc.) never touch the protected checkout, so allow them
+    # regardless of the current repo's branch.
+    in_repo_targets = [p for p in target_paths if path_within_repo(p, repo_root, cwd)]
+    if not in_repo_targets:
+        sys.exit(0)
+
     protected_branch_error = ensure_protected_branch_edit_allowed(repo_root)
     if protected_branch_error:
         emit_event(
@@ -661,7 +696,7 @@ def main() -> None:
         print(protected_branch_error, file=sys.stderr)
         sys.exit(2)
 
-    for target_path in target_paths:
+    for target_path in in_repo_targets:
         lock_error = ensure_main_rs_lock(target_path, session_id)
         if lock_error:
             emit_event(
@@ -701,7 +736,7 @@ def main() -> None:
 
         path_patterns = file_triggers.get("pathPatterns", [])
         matched_target = ""
-        for target_path in target_paths:
+        for target_path in in_repo_targets:
             if not match_path_patterns(target_path, path_patterns):
                 continue
             path_exclusions = file_triggers.get("pathExclusions", [])
@@ -763,7 +798,7 @@ def main() -> None:
 
         path_patterns = file_triggers.get("pathPatterns", [])
         matched_target = ""
-        for target_path in target_paths:
+        for target_path in in_repo_targets:
             if not match_path_patterns(target_path, path_patterns):
                 continue
             path_exclusions = file_triggers.get("pathExclusions", [])

--- a/openspec/changes/agent-claude-skill-guard-never-blocks-edits-to-files-2026-06-03-12-40/.openspec.yaml
+++ b/openspec/changes/agent-claude-skill-guard-never-blocks-edits-to-files-2026-06-03-12-40/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/agent-claude-skill-guard-never-blocks-edits-to-files-2026-06-03-12-40/notes.md
+++ b/openspec/changes/agent-claude-skill-guard-never-blocks-edits-to-files-2026-06-03-12-40/notes.md
@@ -1,0 +1,49 @@
+# agent-claude-skill-guard-never-blocks-edits-to-files-2026-06-03-12-40 (minimal / T1)
+
+Branch: `agent/claude/skill-guard-never-blocks-edits-to-files-2026-06-03-12-40`
+
+`skill_guard.py` (PreToolUse hook) no longer blocks Edit/Write to files OUTSIDE
+the guarded repo (e.g. `~/.claude/.../memory/*.md`) when the repo checkout is on
+a protected branch.
+
+## Why
+
+`find_repo_root` falls back to `Path.cwd()` when it can't find a `.git` walking
+up from the target. For a memory file under `~/.claude` (home is not a git repo),
+that fallback wrongly attributed the file to the current repo (on `main`), so the
+protected-branch guard blocked it: "Agent edit attempted on protected branch
+'main'." Whether a memory write succeeded depended on what branch the unrelated
+cwd repo was on — clearly wrong.
+
+## How
+
+- New `path_within_repo(target, repo_root, cwd)`: True only when the target
+  resolves to a path inside the repo working tree (both sides `.resolve()`d, so
+  `..`/symlinks are canonicalized first). Relative targets resolve against cwd.
+- `main()` computes `in_repo_targets`; if a tool touches NO in-repo file it exits
+  0 (allow). The protected-branch check, `main_rs_lock` loop, and skill-rules
+  loops now operate on `in_repo_targets` only. In-repo edits on protected
+  branches are still blocked; agent-branch edits still allowed.
+- Canonical file `.claude/hooks/skill_guard.py` (`.codex/hooks/` is a symlink to
+  it). Distributed to other repos via `gx claude install`.
+
+## Verify
+
+- `node --test test/skill-guard-hook.test.js` — new tests: out-of-repo write on
+  `main` ALLOWED; in-repo write on `main` BLOCKED; in-repo write on `agent/*`
+  ALLOWED. Full suite: zero regressions (same-environment baseline diff empty).
+- 5 pre-existing failures in this file (claude/codex/cursor branch `rm` tests)
+  are unrelated: the global `[agent-branch-guard]` pre-commit rejects the seed
+  commit in `makeRepoOn` for non-agent branches, failing before the hook runs.
+  Identical on baseline.
+
+## Follow-ups (out of scope)
+
+- `find_repo_root` resolves relative targets against process cwd, a latent
+  relative-path edge in the rare process-cwd != session-cwd case (pre-existing).
+
+## Cleanup
+
+- [ ] Run: `gx branch finish --branch agent/claude/skill-guard-never-blocks-edits-to-files-2026-06-03-12-40 --base main --via-pr --wait-for-merge --cleanup`
+- [ ] Record PR URL + `MERGED` state in the completion handoff.
+- [ ] Confirm sandbox worktree is gone (`git worktree list`, `git branch -a`).

--- a/test/skill-guard-hook.test.js
+++ b/test/skill-guard-hook.test.js
@@ -60,6 +60,50 @@ function bashPayload(cmd, cwd) {
   };
 }
 
+function writePayload(filePath, cwd) {
+  return {
+    session_id: 'skill-guard-test',
+    cwd,
+    tool_name: 'Write',
+    tool_input: { file_path: filePath, content: 'x\n' },
+  };
+}
+
+test('skill_guard ALLOWS writing a file OUTSIDE the repo on a protected branch (memory writes)', () => {
+  const dir = makeRepoOn('main');
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-guard-outside-'));
+  try {
+    // cwd is the repo (on main), but the target lives outside the repo working
+    // tree — it can never touch the protected checkout, so it must be allowed.
+    const result = invokeHook(dir, writePayload(path.join(outside, 'memory.md'), dir));
+    assert.equal(result.status, 0, `out-of-repo write must be allowed: ${result.stderr || result.stdout}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  }
+});
+
+test('skill_guard still BLOCKS writing a file INSIDE the repo on a protected branch', () => {
+  const dir = makeRepoOn('main');
+  try {
+    const result = invokeHook(dir, writePayload(path.join(dir, 'src', 'foo.js'), dir));
+    assert.equal(result.status, 2, `in-repo write on main must still be blocked: ${result.stderr}`);
+    assert.match(result.stderr, /BLOCKED/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('skill_guard allows writing a file INSIDE the repo on an agent/* branch', () => {
+  const dir = makeRepoOn('agent/test/lane');
+  try {
+    const result = invokeHook(dir, writePayload(path.join(dir, 'src', 'foo.js'), dir));
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('skill_guard exit code is 0 (allow) for read-only command on protected branch', () => {
   const dir = makeRepoOn('main');
   try {


### PR DESCRIPTION
Automated by gx branch finish (PR flow).