### PR TITLE
perf: memoize npm-list-g probe, route runtime through probe cache, fix budget gh-bin (plan phase 3)

### DIFF
--- a/openspec/changes/agent-claude-phase3-perf-memoize-probes-and-gh-bin-2026-06-03-12-38/.openspec.yaml
+++ b/openspec/changes/agent-claude-phase3-perf-memoize-probes-and-gh-bin-2026-06-03-12-38/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/agent-claude-phase3-perf-memoize-probes-and-gh-bin-2026-06-03-12-38/notes.md
+++ b/openspec/changes/agent-claude-phase3-perf-memoize-probes-and-gh-bin-2026-06-03-12-38/notes.md
@@ -1,0 +1,34 @@
+# phase3-perf-memoize-probes-and-gh-bin (minimal / T1)
+
+Branch: `agent/claude/phase3-perf-memoize-probes-and-gh-bin-2026-06-03-12-38`
+
+Phase 3 of the gitguardex improvement plan: perf + correctness. No observable behavior change. 3 files, +28.
+
+## Scope
+
+- **B1** `src/core/runtime.js`: route `run()` through `context.cachedSpawn` instead of raw `spawnSync`.
+  cachedSpawn caches ONLY a strict allowlist (git geometry probes, git/gh `--version`, `which`/`command`/`type`);
+  writes, ref resolution, npm, gh auth/pr all fall through to a real spawn. Dedups redundant probes process-wide.
+- **B2** `src/toolchain/index.js`: memoize `detectGlobalToolchainPackages` (slow `npm list -g`, ~1.5s).
+  Bare-`gx` queries it 2× (openspec update-check `toolchain:181` + status snapshot `status.js:30`) → now 1×.
+  Busted via `resetGlobalToolchainDetectionCache()` after a successful global `npm i -g`; reset exported.
+- **B6** `src/budget/index.js`: `runGh` uses imported `GH_BIN` (honors `GUARDEX_GH_BIN`/`ghx`) instead of hardcoded `'gh'`.
+
+## Verification
+
+- `node --test test/*.test.js`: 563 pass / 34 fail / 1 skip. Failing set is **byte-identical** to base
+  (stash-isolated diff: `comm` shows zero new failures, zero fixed). The 34 are pre-existing env/CI baseline.
+- Benchmark (counted `npm list -g` spawns, bare `gx`, fake npm): **baseline 2 → memoized 1**.
+- Memo identity proven (2nd call `===` cached; reset re-probes). Modules load clean; `gx --help`/`prompt --snippet` OK.
+- Independent review: NO BLOCKING FINDINGS (verified post-install re-detect at `status.js:143-146` is handled by the reset).
+
+## Follow-ups (out of scope)
+
+- `src/cli/shared/toolchain-shims.js:285` has a documented-dead duplicate of `detectGlobalToolchainPackages`
+  (un-memoized). Latent footgun if re-wired; candidate for a later dead-code pass.
+
+## Cleanup
+
+- [ ] Finish via the GATED path (not bare `--wait-for-merge`, which is fail-open): `/autoship` or `gx branch finish --gate-review`.
+- [ ] Record PR URL + `MERGED` state. NOTE: repo CI `test (node 20)` is baseline-RED (PR #613 merged red), so green-CI gating may block.
+- [ ] Confirm sandbox worktree pruned.

--- a/src/budget/index.js
+++ b/src/budget/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const cp = require('node:child_process');
+const { GH_BIN } = require('../context');
 
 const TOOL_NAME = 'gx';
 
@@ -8,7 +9,7 @@ const DEFAULT_WARN_NET_USD = 1; // any paid spend at all
 const DEFAULT_CRITICAL_NET_USD = 10; // paid spend that has caused merge blocks before
 
 function runGh(args) {
-  const result = cp.spawnSync('gh', args, { encoding: 'utf8' });
+  const result = cp.spawnSync(GH_BIN, args, { encoding: 'utf8' });
   if (result.error) {
     const err = new Error(`gh binary not found: ${result.error.message}`);
     err.code = 'GH_BIN_MISSING';

--- a/src/core/runtime.js
+++ b/src/core/runtime.js
@@ -1,6 +1,7 @@
 const {
   fs,
   path,
+  cachedSpawn,
   CLI_ENTRY_PATH,
   PACKAGE_SCRIPT_ASSETS,
 } = require('../context');
@@ -13,8 +14,12 @@ function requireValue(rawArgs, index, flagName) {
   return value;
 }
 
+// Route reads through the process-scoped probe cache. cachedSpawn caches ONLY a
+// strict allowlist (git geometry probes, git/gh `--version`, `which`) and falls
+// through to a real spawn for everything else — writes, ref resolution, npm,
+// gh auth/pr — so observable behavior is unchanged, only redundant probes drop.
 function run(cmd, args, options = {}) {
-  return require('node:child_process').spawnSync(cmd, args, {
+  return cachedSpawn(cmd, args, {
     encoding: 'utf8',
     stdio: options.stdio || 'pipe',
     cwd: options.cwd,

--- a/src/toolchain/index.js
+++ b/src/toolchain/index.js
@@ -293,7 +293,24 @@ function buildMissingCompanionInstallPrompt(missingPackages, missingLocalTools) 
   return `${dependencyPrefix}Install missing companion tools now? (${installCommands.join(' && ')})`;
 }
 
+// Process-scoped memo for the slow `npm list -g` probe (~1.6-2.4s). Detection is
+// invariant within one gx invocation, but the bare-`gx`/`gx status` path queries
+// it twice (self-update check + status snapshot). Busted after a global install.
+let globalToolchainDetectionCache = null;
+
+function resetGlobalToolchainDetectionCache() {
+  globalToolchainDetectionCache = null;
+}
+
 function detectGlobalToolchainPackages() {
+  if (globalToolchainDetectionCache) {
+    return globalToolchainDetectionCache;
+  }
+  globalToolchainDetectionCache = computeGlobalToolchainPackages();
+  return globalToolchainDetectionCache;
+}
+
+function computeGlobalToolchainPackages() {
   const result = run(NPM_BIN, ['list', '-g', '--depth=0', '--json']);
   if (result.status !== 0) {
     const stderr = (result.stderr || '').trim();
@@ -563,6 +580,8 @@ function performCompanionInstall(missingPackages, missingLocalTools) {
       };
     }
     installed.push(...missingPackages);
+    // Global package set changed; drop the memo so any later detection re-probes.
+    resetGlobalToolchainDetectionCache();
   }
 
   for (const tool of missingLocalTools) {
@@ -599,6 +618,7 @@ module.exports = {
   describeCompanionInstallCommands,
   buildMissingCompanionInstallPrompt,
   detectGlobalToolchainPackages,
+  resetGlobalToolchainDetectionCache,
   detectRequiredSystemTools,
   detectOptionalLocalCompanionTools,
   askGlobalInstallForMissing,


### PR DESCRIPTION
## Summary
- perf: memoize npm-list-g probe, route runtime through probe cache, fix budget gh-bin (plan phase 3)

## Test plan
- [ ] verified locally