### PR TITLE
perf(preflight): quiet by default + fix single-failing-step false pass

### DIFF
--- a/openspec/changes/agent-claude-agent-preflight-quiet-by-default-capture-2026-06-05-16-08/.openspec.yaml
+++ b/openspec/changes/agent-claude-agent-preflight-quiet-by-default-capture-2026-06-05-16-08/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/agent-claude-agent-preflight-quiet-by-default-capture-2026-06-05-16-08/proposal.md
+++ b/openspec/changes/agent-claude-agent-preflight-quiet-by-default-capture-2026-06-05-16-08/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`gx branch finish` runs `scripts/agent-preflight.sh`, whose `run_step` streamed
+each check's stdout live. A green `npm test` (`node --test test/*.test.js`) is
+hundreds of lines of TAP, so every finish flooded the agent's context with
+output it does not need on success. The audit ranked this the top token sink
+after the per-turn advisory.
+
+## What Changes
+
+- `run_step` is QUIET by default: it captures each step's combined output,
+  prints a one-line `ok (N lines suppressed)` summary on success, and shows only
+  the last N lines (default 40) on failure (where the output is useful).
+- `GUARDEX_PREFLIGHT_VERBOSE=1` restores live streaming; `GUARDEX_PREFLIGHT_FAIL_TAIL`
+  tunes the failure tail length.
+- Latent-bug fix: stack detection now keys on an `attempted` counter, not the
+  passed-steps `ran` counter, so a single failing step no longer reports "No
+  recognized project stack detected" and exits 0 (false pass).
+
+## Impact
+
+- **Affected**: `templates/scripts/agent-preflight.sh` (symlinked from
+  `scripts/agent-preflight.sh`). Runs in every `gx branch finish` preflight.
+- **Behavior**: green preflights are quiet by default; failures still surface a
+  diagnosable tail and still refuse the push. `set -e` safe (capture via `if`).
+- Verified by `test/agent-preflight-quiet.test.js` (suppress / verbose / fail-tail).

--- a/openspec/changes/agent-claude-agent-preflight-quiet-by-default-capture-2026-06-05-16-08/specs/agent-preflight-quiet-by-default-capture-test-output-summary-on-pass-tail-on-fail/spec.md
+++ b/openspec/changes/agent-claude-agent-preflight-quiet-by-default-capture-2026-06-05-16-08/specs/agent-preflight-quiet-by-default-capture-test-output-summary-on-pass-tail-on-fail/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Preflight output is quiet by default
+The preflight `run_step` SHALL suppress a passing step's output, emitting only a
+one-line summary, and SHALL surface output only when a step fails.
+
+#### Scenario: Passing step is summarized
+- **WHEN** a preflight step passes
+- **THEN** its full output is not printed; a one-line `ok (N lines suppressed)` summary is, reporting how many lines were hidden.
+
+#### Scenario: Failing step stays diagnosable
+- **WHEN** a preflight step fails
+- **THEN** the tail of its output (default 40 lines) is printed to stderr and the preflight exits non-zero (refusing the push).
+
+#### Scenario: Verbose opt-in
+- **WHEN** `GUARDEX_PREFLIGHT_VERBOSE=1` is set
+- **THEN** every step streams its full output live.
+
+#### Scenario: A single failing step is not masked
+- **WHEN** the only recognized check fails
+- **THEN** the preflight exits non-zero (not the "no stack detected" exit-0 path).

--- a/openspec/changes/agent-claude-agent-preflight-quiet-by-default-capture-2026-06-05-16-08/tasks.md
+++ b/openspec/changes/agent-claude-agent-preflight-quiet-by-default-capture-2026-06-05-16-08/tasks.md
@@ -1,0 +1,34 @@
+## Definition of Done
+
+This change is complete only when **all** of the following are true:
+
+- Every checkbox below is checked.
+- The agent branch reaches `MERGED` state on `origin` and the PR URL + state are recorded in the completion handoff.
+- If any step blocks (test failure, conflict, ambiguous result), append a `BLOCKED:` line under section 4 explaining the blocker and **STOP**. Do not tick remaining cleanup boxes; do not silently skip the cleanup pipeline.
+
+## Handoff
+
+- Handoff: change=`agent-claude-agent-preflight-quiet-by-default-capture-2026-06-05-16-08`; branch=`agent/<your-name>/<branch-slug>`; scope=`TODO`; action=`continue this sandbox or finish cleanup after a usage-limit/manual takeover`.
+- Copy prompt: Continue `agent-claude-agent-preflight-quiet-by-default-capture-2026-06-05-16-08` on branch `agent/<your-name>/<branch-slug>`. Work inside the existing sandbox, review `openspec/changes/agent-claude-agent-preflight-quiet-by-default-capture-2026-06-05-16-08/tasks.md`, continue from the current state instead of creating a new sandbox, and when the work is done run `gx branch finish --branch agent/<your-name>/<branch-slug> --base dev --via-pr --wait-for-merge --cleanup`.
+
+## 1. Specification
+
+- [x] 1.1 Finalize proposal scope and acceptance criteria for `agent-claude-agent-preflight-quiet-by-default-capture-2026-06-05-16-08`.
+- [x] 1.2 Define normative requirements in `specs/agent-preflight-quiet-by-default-capture-test-output-summary-on-pass-tail-on-fail/spec.md`.
+
+## 2. Implementation
+
+- [x] 2.1 Implement scoped behavior changes.
+- [x] 2.2 Add/update focused regression coverage.
+
+## 3. Verification
+
+- [x] 3.1 Run targeted project verification commands.
+- [x] 3.2 Run `openspec validate agent-claude-agent-preflight-quiet-by-default-capture-2026-06-05-16-08 --type change --strict`.
+- [x] 3.3 Run `openspec validate --specs`.
+
+## 4. Cleanup (mandatory; run before claiming completion)
+
+- [ ] 4.1 Run the cleanup pipeline: `gx branch finish --branch agent/<your-name>/<branch-slug> --base dev --via-pr --wait-for-merge --cleanup`. This handles commit -> push -> PR create -> merge wait -> worktree prune in one invocation.
+- [ ] 4.2 Record the PR URL and final merge state (`MERGED`) in the completion handoff.
+- [ ] 4.3 Confirm the sandbox worktree is gone (`git worktree list` no longer shows the agent path; `git branch -a` shows no surviving local/remote refs for the branch).

--- a/templates/scripts/agent-preflight.sh
+++ b/templates/scripts/agent-preflight.sh
@@ -22,17 +22,43 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$repo_root"
 
-ran=0
+ran=0        # steps that PASSED
+attempted=0  # steps that RAN (pass or fail) — drives stack detection
 fail=0
+# Quiet by default: a green `npm test` run can be hundreds of lines of TAP that
+# floods the agent's context on every `gx branch finish`. Capture each step's
+# output, print a one-line summary on success, and surface only the tail on
+# failure (where it is actually useful). Stream full output live with
+# GUARDEX_PREFLIGHT_VERBOSE=1.
+GUARDEX_PREFLIGHT_FAIL_TAIL="${GUARDEX_PREFLIGHT_FAIL_TAIL:-40}"
 run_step() {
   local label="$1"
   shift
   echo "[agent-preflight] -> $label"
-  if "$@"; then
-    ran=$((ran + 1))
-    echo "[agent-preflight]    ok"
+  attempted=$((attempted + 1))
+  if [[ "${GUARDEX_PREFLIGHT_VERBOSE:-0}" == "1" ]]; then
+    if "$@"; then
+      ran=$((ran + 1))
+      echo "[agent-preflight]    ok"
+    else
+      echo "[agent-preflight] FAIL: $label" >&2
+      fail=1
+    fi
+    return 0
+  fi
+  local out rc
+  # `if` keeps `set -e` from aborting on a failing step before we capture rc.
+  if out="$("$@" 2>&1)"; then
+    rc=0
   else
-    echo "[agent-preflight] FAIL: $label" >&2
+    rc=$?
+  fi
+  if [[ "$rc" -eq 0 ]]; then
+    ran=$((ran + 1))
+    echo "[agent-preflight]    ok ($(printf '%s\n' "$out" | wc -l | tr -d ' ') lines suppressed; GUARDEX_PREFLIGHT_VERBOSE=1 to show)"
+  else
+    echo "[agent-preflight] FAIL: $label (exit $rc) — last ${GUARDEX_PREFLIGHT_FAIL_TAIL} lines:" >&2
+    printf '%s\n' "$out" | tail -n "$GUARDEX_PREFLIGHT_FAIL_TAIL" >&2
     fail=1
   fi
 }
@@ -74,7 +100,7 @@ if [[ -f pyproject.toml ]] && command -v ruff >/dev/null 2>&1; then
   run_step "ruff check" ruff check .
 fi
 
-if [[ "$ran" -eq 0 ]]; then
+if [[ "$attempted" -eq 0 ]]; then
   echo "[agent-preflight] No recognized project stack detected; skipping checks." >&2
   exit 0
 fi

--- a/test/agent-preflight-quiet.test.js
+++ b/test/agent-preflight-quiet.test.js
@@ -1,0 +1,73 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const cp = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const scriptPath = path.resolve(__dirname, '..', 'templates', 'scripts', 'agent-preflight.sh');
+
+// A minimal Node repo whose `npm test` runs the given inline node script, so the
+// preflight's run_step is exercised end-to-end.
+function makeNodeRepo(testScript) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'preflight-'));
+  cp.spawnSync('git', ['init', '-q'], { cwd: dir });
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: 'x', version: '1.0.0', scripts: { test: testScript } }, null, 2),
+  );
+  // package-lock.json + npm => the script's npm branch fires.
+  fs.writeFileSync(
+    path.join(dir, 'package-lock.json'),
+    JSON.stringify({ name: 'x', version: '1.0.0', lockfileVersion: 3, packages: {} }, null, 2),
+  );
+  return dir;
+}
+
+function runPreflight(dir, env = {}) {
+  const res = cp.spawnSync('bash', [scriptPath], {
+    cwd: dir,
+    encoding: 'utf8',
+    timeout: 60000,
+    env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null', ...env },
+  });
+  return { status: res.status, out: `${res.stdout || ''}${res.stderr || ''}` };
+}
+
+const NOISY_PASS = "node -e \"for(let i=0;i<200;i++)console.log('NOISE'+i)\"";
+
+test('preflight SUPPRESSES a passing step\'s output by default (no context flood)', () => {
+  const dir = makeNodeRepo(NOISY_PASS);
+  try {
+    const { status, out } = runPreflight(dir);
+    assert.equal(status, 0, out);
+    assert.doesNotMatch(out, /NOISE100/, 'noisy test output must be suppressed on success');
+    assert.match(out, /lines suppressed/, 'reports how many lines were hidden (no silent cap)');
+    assert.match(out, /\[agent-preflight] {4}ok/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('GUARDEX_PREFLIGHT_VERBOSE=1 streams the full output', () => {
+  const dir = makeNodeRepo(NOISY_PASS);
+  try {
+    const { status, out } = runPreflight(dir, { GUARDEX_PREFLIGHT_VERBOSE: '1' });
+    assert.equal(status, 0, out);
+    assert.match(out, /NOISE100/, 'verbose mode shows the full output');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a FAILING step still surfaces its output (tail) and fails the preflight', () => {
+  const dir = makeNodeRepo("node -e \"console.log('BOOM-DETAIL'); process.exit(1)\"");
+  try {
+    const { status, out } = runPreflight(dir);
+    assert.notEqual(status, 0, 'preflight must fail when a step fails');
+    assert.match(out, /FAIL/);
+    assert.match(out, /BOOM-DETAIL/, 'failure output (tail) is shown so it stays diagnosable');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Quiet `agent-preflight.sh` (capture step output, summary on pass, 40-line tail on fail; `GUARDEX_PREFLIGHT_VERBOSE=1` opt-out) so a green `npm test` stops flooding agent context on every `gx branch finish`. Also fixes a latent bug where a single failing check exited 0 (false pass) via an `attempted` counter.

Gate: independent review clean (no CRITICAL/HIGH); failing-test set byte-identical to base (23=23, zero NEW). Baseline-red repo, landed with the manual gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)