### PR TITLE
feat(branch): default gx branch start to tier T1, not T3

### DIFF
--- a/.agent/CLAUDE-CODE-WORKFLOW.md
+++ b/.agent/CLAUDE-CODE-WORKFLOW.md
@@ -22,7 +22,7 @@ gx branch start --tier T0 "fix-typo-in-readme" "claude-name"
 # T1 (small fix): notes-only scaffold, commit message is the spec of record
 gx branch start --tier T1 "tighten-retry-backoff" "claude-name"
 
-# T2 (default for real behavior changes): full change spec, no plan workspace
+# T2 (explicit; real behavior changes): full change spec, no plan workspace
 gx branch start --tier T2 "add-oauth-endpoint" "claude-name"
 
 # T3 (explicit; plan-driven): plan workspace + full OpenSpec

--- a/.agent/CLAUDE-CODE-WORKFLOW.md
+++ b/.agent/CLAUDE-CODE-WORKFLOW.md
@@ -4,7 +4,7 @@ When Guardex is enabled, Claude Code sessions use the same agent-worktree + Open
 
 ## Tiering (token-aware scaffolding)
 
-`gx branch start` and `gx branch finish` accept `--tier {T0|T1|T2|T3}` to size the OpenSpec scaffolding to the change's blast radius. Default is `T3` (full scaffolding; current behavior). The tier is recorded in the bootstrap manifest so `finish` picks it up automatically.
+`gx branch start` and `gx branch finish` accept `--tier {T0|T1|T2|T3}` to size the OpenSpec scaffolding to the change's blast radius. Default is `T1` (notes.md only — most tasks are small, and a full T3 plan workspace costs thousands of tokens an agent never reads). Escalate explicitly with `--tier T2` for a behavior change or `--tier T3` for plan-driven work. The tier is recorded in the bootstrap manifest so `finish` picks it up automatically.
 
 | Tier | Use for | Scaffolding on `start` | Gates on `finish` |
 |------|---------|------------------------|--------------------|
@@ -25,8 +25,8 @@ gx branch start --tier T1 "tighten-retry-backoff" "claude-name"
 # T2 (default for real behavior changes): full change spec, no plan workspace
 gx branch start --tier T2 "add-oauth-endpoint" "claude-name"
 
-# T3 (current default if --tier is omitted): plan workspace + full OpenSpec
-gx branch start "refactor-payment-pipeline" "claude-name"
+# T3 (explicit; plan-driven): plan workspace + full OpenSpec
+gx branch start --tier T3 "refactor-payment-pipeline" "claude-name"
 ```
 
 `finish` reads the tier from the manifest automatically; passing `--tier` on finish is only needed to override (e.g., upgrading to a fuller gate).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,8 @@ gh pr merge <PR-NUMBER> --repo <owner>/<repo> --auto --squash
 gx finish --all
 ```
 
-Tier guide (sized by blast radius; default is `T3` if `--tier` is omitted):
+Tier guide (sized by blast radius; **default is `T1`** when `--tier` is omitted —
+escalate with `--tier T2` for a behavior change or `--tier T3` for plan-driven work):
 
 | Tier | Use for | Scaffolding | Gates |
 |------|---------|-------------|-------|

--- a/openspec/changes/agent-claude-default-gx-branch-start-tier-to-t1-not-t-2026-06-05-16-29/.openspec.yaml
+++ b/openspec/changes/agent-claude-default-gx-branch-start-tier-to-t1-not-t-2026-06-05-16-29/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/agent-claude-default-gx-branch-start-tier-to-t1-not-t-2026-06-05-16-29/proposal.md
+++ b/openspec/changes/agent-claude-default-gx-branch-start-tier-to-t1-not-t-2026-06-05-16-29/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`gx branch start` defaulted to tier T3 (full change + plan workspace, ~7290
+tokens of scaffolding) when `--tier` was omitted. Most tasks are small (a fix, a
+tweak) and never touch the plan workspace, so every default branch-start paid
+thousands of tokens an agent immediately ignores. The audit ranked flipping this
+default the highest-leverage scaffold fix.
+
+## What Changes
+
+- Default tier flips from T3 to **T1** (notes.md only) in
+  `templates/scripts/agent-branch-start.sh` (`GUARDEX_OPENSPEC_TIER` default and
+  the `normalize_tier` fallback).
+- `gx branch start` prints an escalation hint on T1: use `--tier T2` for a
+  behavior change, `--tier T3` for plan-driven work.
+- Usage text + the tier-guide docs (`AGENTS.md`, `.agent/CLAUDE-CODE-WORKFLOW.md`)
+  updated to state the new default.
+
+## Impact
+
+- **Affected**: `templates/scripts/agent-branch-start.sh` (symlinked from
+  `scripts/`), `AGENTS.md`, `.agent/CLAUDE-CODE-WORKFLOW.md`.
+- **Behavior**: omitting `--tier` now yields the minimal scaffold; behavior
+  changes must opt up with `--tier T2/T3` (the hint + docs guide this). Explicit
+  `--tier` and `GUARDEX_OPENSPEC_TIER` are unaffected.
+- **Follow-up (not in this change)**: auto-escalation when an agent writes
+  proposal.md/spec.md into a T1 change — needs a separate runtime hook.
+- Verified by `test/branch.test.js` ("DEFAULTS to T1 ... when --tier is omitted").

--- a/openspec/changes/agent-claude-default-gx-branch-start-tier-to-t1-not-t-2026-06-05-16-29/specs/default-gx-branch-start-tier-to-t1-not-t3-for-small-changes/spec.md
+++ b/openspec/changes/agent-claude-default-gx-branch-start-tier-to-t1-not-t-2026-06-05-16-29/specs/default-gx-branch-start-tier-to-t1-not-t3-for-small-changes/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: gx branch start defaults to tier T1
+`gx branch start` SHALL scaffold at tier T1 (notes.md only) when `--tier` is omitted and `GUARDEX_OPENSPEC_TIER` is unset, instead of the former T3 default.
+
+#### Scenario: Omitted tier yields T1
+- **WHEN** `gx branch start "<task>" "<name>"` runs without `--tier`
+- **THEN** the OpenSpec change scaffold contains `notes.md` and no `proposal.md`, and no plan workspace is created
+- **AND** the output reports `OpenSpec tier: T1` with an escalation hint.
+
+#### Scenario: Explicit tier still honored
+- **WHEN** `--tier T2` or `--tier T3` (or `GUARDEX_OPENSPEC_TIER`) is given
+- **THEN** the corresponding fuller scaffolding is created, unchanged from before.

--- a/openspec/changes/agent-claude-default-gx-branch-start-tier-to-t1-not-t-2026-06-05-16-29/tasks.md
+++ b/openspec/changes/agent-claude-default-gx-branch-start-tier-to-t1-not-t-2026-06-05-16-29/tasks.md
@@ -1,0 +1,34 @@
+## Definition of Done
+
+This change is complete only when **all** of the following are true:
+
+- Every checkbox below is checked.
+- The agent branch reaches `MERGED` state on `origin` and the PR URL + state are recorded in the completion handoff.
+- If any step blocks (test failure, conflict, ambiguous result), append a `BLOCKED:` line under section 4 explaining the blocker and **STOP**. Do not tick remaining cleanup boxes; do not silently skip the cleanup pipeline.
+
+## Handoff
+
+- Handoff: change=`agent-claude-default-gx-branch-start-tier-to-t1-not-t-2026-06-05-16-29`; branch=`agent/<your-name>/<branch-slug>`; scope=`TODO`; action=`continue this sandbox or finish cleanup after a usage-limit/manual takeover`.
+- Copy prompt: Continue `agent-claude-default-gx-branch-start-tier-to-t1-not-t-2026-06-05-16-29` on branch `agent/<your-name>/<branch-slug>`. Work inside the existing sandbox, review `openspec/changes/agent-claude-default-gx-branch-start-tier-to-t1-not-t-2026-06-05-16-29/tasks.md`, continue from the current state instead of creating a new sandbox, and when the work is done run `gx branch finish --branch agent/<your-name>/<branch-slug> --base dev --via-pr --wait-for-merge --cleanup`.
+
+## 1. Specification
+
+- [x] 1.1 Finalize proposal scope and acceptance criteria for `agent-claude-default-gx-branch-start-tier-to-t1-not-t-2026-06-05-16-29`.
+- [x] 1.2 Define normative requirements in `specs/default-gx-branch-start-tier-to-t1-not-t3-for-small-changes/spec.md`.
+
+## 2. Implementation
+
+- [x] 2.1 Implement scoped behavior changes.
+- [x] 2.2 Add/update focused regression coverage.
+
+## 3. Verification
+
+- [x] 3.1 Run targeted project verification commands.
+- [x] 3.2 Run `openspec validate agent-claude-default-gx-branch-start-tier-to-t1-not-t-2026-06-05-16-29 --type change --strict`.
+- [x] 3.3 Run `openspec validate --specs`.
+
+## 4. Cleanup (mandatory; run before claiming completion)
+
+- [ ] 4.1 Run the cleanup pipeline: `gx branch finish --branch agent/<your-name>/<branch-slug> --base dev --via-pr --wait-for-merge --cleanup`. This handles commit -> push -> PR create -> merge wait -> worktree prune in one invocation.
+- [ ] 4.2 Record the PR URL and final merge state (`MERGED`) in the completion handoff.
+- [ ] 4.3 Confirm the sandbox worktree is gone (`git worktree list` no longer shows the agent path; `git branch -a` shows no surviving local/remote refs for the branch).

--- a/templates/scripts/agent-branch-merge.sh
+++ b/templates/scripts/agent-branch-merge.sh
@@ -281,7 +281,10 @@ if [[ -z "$TARGET_BRANCH" ]]; then
   start_output=""
   if ! start_output="$(
     cd "$repo_root"
-    GUARDEX_OPENSPEC_AUTO_INIT=1 run_guardex_cli branch start "$TASK_NAME" "$AGENT_NAME" "$BASE_BRANCH" 2>&1
+    # An integration lane is inherently cross-cutting, so pin it to T3 (full
+    # change + plan workspace) regardless of the branch-start default (now T1).
+    GUARDEX_OPENSPEC_AUTO_INIT=1 GUARDEX_OPENSPEC_TIER="${GUARDEX_OPENSPEC_TIER:-T3}" \
+      run_guardex_cli branch start "$TASK_NAME" "$AGENT_NAME" "$BASE_BRANCH" 2>&1
   )"; then
     printf '%s\n' "$start_output" >&2
     exit 1

--- a/templates/scripts/agent-branch-start.sh
+++ b/templates/scripts/agent-branch-start.sh
@@ -14,7 +14,10 @@ OPENSPEC_PLAN_SLUG_OVERRIDE="${GUARDEX_OPENSPEC_PLAN_SLUG:-}"
 OPENSPEC_CHANGE_SLUG_OVERRIDE="${GUARDEX_OPENSPEC_CHANGE_SLUG:-}"
 OPENSPEC_CAPABILITY_SLUG_OVERRIDE="${GUARDEX_OPENSPEC_CAPABILITY_SLUG:-}"
 OPENSPEC_MASTERPLAN_LABEL_RAW="${GUARDEX_OPENSPEC_MASTERPLAN_LABEL-masterplan}"
-OPENSPEC_TIER_RAW="${GUARDEX_OPENSPEC_TIER:-T3}"
+# Default tier is T1 (notes.md only, minimal scaffold): most tasks are small,
+# and a full T3 plan workspace costs thousands of tokens an agent never reads.
+# Escalate explicitly with --tier T2 (behavior change) or T3 (plan-driven).
+OPENSPEC_TIER_RAW="${GUARDEX_OPENSPEC_TIER:-T1}"
 REUSE_EXISTING_RAW="${GUARDEX_BRANCH_START_REUSE_EXISTING:-true}"
 AUTO_TRANSFER_ENABLED_RAW="${GUARDEX_AUTO_TRANSFER:-true}"
 AUTO_TRANSFER_EXCLUDE_DEFAULT='.omc/**:.omx/state/**:.dev-ports.json:apps/logs/**:.codex/settings.local.json:.claude/settings.local.json:.codex/state/**:.claude/state/**'
@@ -57,7 +60,8 @@ Options:
   --worktree-root <p>  Worktree root dir (default: .omx/agent-worktrees)
   --reuse-existing     Reuse an existing matching worktree (default)
   --new                Force a fresh worktree instead of reusing
-  --tier <T1|T2|T3>    OpenSpec tier for scaffolding
+  --tier <T1|T2|T3>    OpenSpec tier for scaffolding (default T1; T2 for a
+                       behavior change, T3 for plan-driven work)
   --transfer           Auto-transfer uncommitted changes into the worktree (default)
   --no-transfer        Do not auto-transfer uncommitted changes
   --transfer-exclude <globs>  Colon-separated globs to exclude from transfer
@@ -323,7 +327,7 @@ normalize_tier() {
   esac
 }
 
-if ! OPENSPEC_TIER="$(normalize_tier "$OPENSPEC_TIER_RAW" "T3")"; then
+if ! OPENSPEC_TIER="$(normalize_tier "$OPENSPEC_TIER_RAW" "T1")"; then
   echo "[agent-branch-start] Unsupported OpenSpec tier: ${OPENSPEC_TIER_RAW}" >&2
   exit 1
 fi
@@ -977,6 +981,9 @@ fi
 echo "[agent-branch-start] Created branch: ${branch_name}"
 echo "[agent-branch-start] Worktree: ${worktree_path}"
 echo "[agent-branch-start] OpenSpec tier: ${OPENSPEC_TIER}"
+if [[ "$OPENSPEC_TIER" == "T1" ]]; then
+  echo "[agent-branch-start] T1 minimal scaffold (notes.md). Escalate: --tier T2 for a behavior change, T3 for plan-driven work."
+fi
 if [[ "$OPENSPEC_AUTO_INIT" -ne 1 ]]; then
   echo "[agent-branch-start] OpenSpec change: skipped (GUARDEX_OPENSPEC_AUTO_INIT disabled)"
 elif [[ "$OPENSPEC_SKIP_CHANGE" -eq 1 ]]; then

--- a/test/branch.test.js
+++ b/test/branch.test.js
@@ -496,6 +496,41 @@ test('agent-branch-start honors T1 notes-only OpenSpec scaffolding', () => {
 });
 
 
+test('agent-branch-start DEFAULTS to T1 scaffolding when --tier is omitted', () => {
+  const repoDir = initRepo();
+  seedCommit(repoDir);
+
+  let result = runNode(['setup', '--target', repoDir, '--no-global-install'], repoDir);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  result = runCmd('git', ['add', '.'], repoDir);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  result = runCmd('git', ['commit', '-m', 'apply gx setup'], repoDir, {
+    ALLOW_COMMIT_ON_PROTECTED_BRANCH: '1',
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  // No --tier: must resolve to T1, not the old T3 default.
+  result = runBranchStart(['tighten copy', 'bot'], repoDir, {
+    GUARDEX_OPENSPEC_AUTO_INIT: 'true',
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /\[agent-branch-start\] OpenSpec tier: T1/);
+  assert.match(result.stdout, /T1 minimal scaffold/, 'prints the escalation hint');
+
+  const createdWorktree = extractCreatedWorktree(result.stdout);
+  const changeSlug = extractOpenSpecChangeSlug(result.stdout);
+  const changeDir = path.join(createdWorktree, 'openspec', 'changes', changeSlug);
+  assert.equal(fs.existsSync(path.join(changeDir, 'notes.md')), true, 'notes.md present for default T1');
+  assert.equal(fs.existsSync(path.join(changeDir, 'proposal.md')), false, 'no proposal.md for default T1');
+  assert.equal(
+    fs.existsSync(path.join(createdWorktree, 'openspec', 'plan', changeSlug)),
+    false,
+    'default T1 must not create a plan workspace',
+  );
+});
+
+
 test('agent-branch-start honors T2 full change scaffolding without a plan workspace', () => {
   const repoDir = initRepo();
   seedCommit(repoDir);


### PR DESCRIPTION
Flip the default OpenSpec tier from T3 (~7290 tokens of change+plan scaffolding) to T1 (notes.md only) for branch-starts that omit `--tier`; escalate explicitly with `--tier T2/T3`. The `gx merge` integration lane is pinned to T3 (cross-cutting, needs the plan workspace). Usage + tier-guide docs updated.

Gate: independent review clean (no CRITICAL/HIGH); failing-test set has zero NEW failures vs base (22 vs 23 — one baseline failure now passes). Baseline-red repo, manual gate.

Follow-up (tracked): auto-escalate when an agent writes proposal.md/spec.md into a T1 change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)