### PR TITLE
feat(mcp): stale-lane detection + pr_lookup_error field

### DIFF
--- a/openspec/changes/agent-claude-gx-mcp-stale-lane-pr-lookup-error-fields-2026-06-05-16-55/.openspec.yaml
+++ b/openspec/changes/agent-claude-gx-mcp-stale-lane-pr-lookup-error-fields-2026-06-05-16-55/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/agent-claude-gx-mcp-stale-lane-pr-lookup-error-fields-2026-06-05-16-55/proposal.md
+++ b/openspec/changes/agent-claude-gx-mcp-stale-lane-pr-lookup-error-fields-2026-06-05-16-55/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Two gaps the gx mcp review left open: (1) `list_agents` could not distinguish a
+lane with no open PR from one whose `gh` lookup *failed* (both showed `pr:null`),
+hiding gh-auth/offline problems; (2) there was no signal for forgotten lanes
+(old, merged/closed, never cleaned up) that an agent could prune.
+
+## What Changes
+
+- `pr.listOpenPrsForRepo` returns `{ prs, error }` instead of a bare array, so a
+  failed lookup is distinguishable from "no open PRs".
+- Each agent record gains `prLookupError` (the lookup error, or null), `ageDays`
+  (days since last commit), and `stale` (true when ageDays > threshold AND no
+  open PR AND no uncommitted work — a safe prune candidate).
+- Threshold via `GUARDEX_MCP_STALE_DAYS` (default 14).
+- `gx mcp list-agents` shows `⚠ STALE Nd` and `PR? (lookup failed)`; tool
+  descriptions updated.
+
+## Impact
+
+- **Affected**: `src/pr.js`, `src/mcp/collect.js`, `src/mcp/server.js`,
+  `src/cli/commands/mcp.js`. `listOpenPrsForRepo` return shape changed (only
+  consumer is the mcp collector). Read-only; no repo mutation.
+- Verified by `test/mcp-collect.test.js` (daysSince / stale fixture / prLookupError).

--- a/openspec/changes/agent-claude-gx-mcp-stale-lane-pr-lookup-error-fields-2026-06-05-16-55/specs/gx-mcp-stale-lane-pr-lookup-error-fields/spec.md
+++ b/openspec/changes/agent-claude-gx-mcp-stale-lane-pr-lookup-error-fields-2026-06-05-16-55/specs/gx-mcp-stale-lane-pr-lookup-error-fields/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Distinguish PR-lookup failure from no open PR
+The collector SHALL set a `prLookupError` field on each lane: the error string when the `gh` PR lookup itself failed, or null when the lookup succeeded (including when it found no open PR).
+
+#### Scenario: gh lookup fails
+- **WHEN** PR lookup runs against a repo where `gh` cannot list (missing, unauthenticated, offline, or no remote)
+- **THEN** each lane's `prLookupError` is a non-empty string and its `pr` is null.
+
+#### Scenario: PRs not requested
+- **WHEN** `include_prs` is false
+- **THEN** `prLookupError` is null (no lookup attempted).
+
+### Requirement: Flag stale lanes
+The collector SHALL set `ageDays` (whole days since the lane's last commit) and `stale` (true when ageDays exceeds the threshold AND the lane has no open PR AND no uncommitted changes) on each lane. The threshold SHALL default to 14 days, overridable via `GUARDEX_MCP_STALE_DAYS`.
+
+#### Scenario: Old idle lane is stale
+- **WHEN** a lane's last commit is older than the threshold, with no open PR and a clean tree
+- **THEN** `stale` is true.
+
+#### Scenario: Fresh or active lane is not stale
+- **WHEN** a lane's last commit is recent (or it has an open PR or uncommitted work)
+- **THEN** `stale` is false.

--- a/openspec/changes/agent-claude-gx-mcp-stale-lane-pr-lookup-error-fields-2026-06-05-16-55/tasks.md
+++ b/openspec/changes/agent-claude-gx-mcp-stale-lane-pr-lookup-error-fields-2026-06-05-16-55/tasks.md
@@ -1,0 +1,34 @@
+## Definition of Done
+
+This change is complete only when **all** of the following are true:
+
+- Every checkbox below is checked.
+- The agent branch reaches `MERGED` state on `origin` and the PR URL + state are recorded in the completion handoff.
+- If any step blocks (test failure, conflict, ambiguous result), append a `BLOCKED:` line under section 4 explaining the blocker and **STOP**. Do not tick remaining cleanup boxes; do not silently skip the cleanup pipeline.
+
+## Handoff
+
+- Handoff: change=`agent-claude-gx-mcp-stale-lane-pr-lookup-error-fields-2026-06-05-16-55`; branch=`agent/<your-name>/<branch-slug>`; scope=`TODO`; action=`continue this sandbox or finish cleanup after a usage-limit/manual takeover`.
+- Copy prompt: Continue `agent-claude-gx-mcp-stale-lane-pr-lookup-error-fields-2026-06-05-16-55` on branch `agent/<your-name>/<branch-slug>`. Work inside the existing sandbox, review `openspec/changes/agent-claude-gx-mcp-stale-lane-pr-lookup-error-fields-2026-06-05-16-55/tasks.md`, continue from the current state instead of creating a new sandbox, and when the work is done run `gx branch finish --branch agent/<your-name>/<branch-slug> --base dev --via-pr --wait-for-merge --cleanup`.
+
+## 1. Specification
+
+- [x] 1.1 Finalize proposal scope and acceptance criteria for `agent-claude-gx-mcp-stale-lane-pr-lookup-error-fields-2026-06-05-16-55`.
+- [x] 1.2 Define normative requirements in `specs/gx-mcp-stale-lane-pr-lookup-error-fields/spec.md`.
+
+## 2. Implementation
+
+- [x] 2.1 Implement scoped behavior changes.
+- [x] 2.2 Add/update focused regression coverage.
+
+## 3. Verification
+
+- [x] 3.1 Run targeted project verification commands.
+- [x] 3.2 Run `openspec validate agent-claude-gx-mcp-stale-lane-pr-lookup-error-fields-2026-06-05-16-55 --type change --strict`.
+- [x] 3.3 Run `openspec validate --specs`.
+
+## 4. Cleanup (mandatory; run before claiming completion)
+
+- [ ] 4.1 Run the cleanup pipeline: `gx branch finish --branch agent/<your-name>/<branch-slug> --base dev --via-pr --wait-for-merge --cleanup`. This handles commit -> push -> PR create -> merge wait -> worktree prune in one invocation.
+- [ ] 4.2 Record the PR URL and final merge state (`MERGED`) in the completion handoff.
+- [ ] 4.3 Confirm the sandbox worktree is gone (`git worktree list` no longer shows the agent path; `git branch -a` shows no surviving local/remote refs for the branch).

--- a/src/cli/commands/mcp.js
+++ b/src/cli/commands/mcp.js
@@ -27,13 +27,16 @@ function printUsage() {
 }
 
 function fmtAgent(a) {
-  const pr = a.pr ? `PR #${a.pr.number} (${a.pr.state}${a.pr.isDraft ? ', draft' : ''})` : a.pushed ? 'pushed, no open PR' : 'local only';
+  const pr = a.prLookupError
+    ? `PR? (lookup failed)`
+    : a.pr ? `PR #${a.pr.number} (${a.pr.state}${a.pr.isDraft ? ', draft' : ''})` : a.pushed ? 'pushed, no open PR' : 'local only';
   const locks = a.locks && a.locks.length ? `${a.locks.length} lock(s)` : 'no locks';
   const dirty = a.dirty && a.dirty.length ? `editing ${a.dirty.length} file(s)` : 'clean';
   const when = a.lastCommit && a.lastCommit.date ? a.lastCommit.date.replace('T', ' ').replace(/\..*$/, '') : '?';
   const warn = a.warning ? '  ⚠ ON PRIMARY CHECKOUT' : '';
+  const stale = a.stale ? `  ⚠ STALE ${a.ageDays}d` : '';
   return [
-    `• ${a.repo}  ${a.branch}${warn}`,
+    `• ${a.repo}  ${a.branch}${warn}${stale}`,
     `    agent=${a.agent || '?'}  task=${a.task}`,
     `    ${dirty}  ${locks}  ${pr}  last=${when}`,
     `    worktree=${a.worktree}`,

--- a/src/mcp/collect.js
+++ b/src/mcp/collect.js
@@ -335,6 +335,7 @@ function myContext({ cwd = process.cwd(), includePr = true } = {}) {
   const mainRoot = mainRepoRoot(cwd) || here;
   const branch = git(here, ['rev-parse', '--abbrev-ref', 'HEAD']);
   const self = listWorktrees(mainRoot).find((w) => path.resolve(w.path) === path.resolve(here));
+  const lc = branch ? lastCommit(mainRoot, branch) : null;
   return {
     repo: repoName(mainRoot),
     repoPath: mainRoot,
@@ -346,8 +347,8 @@ function myContext({ cwd = process.cwd(), includePr = true } = {}) {
     dirty: dirtyFiles(here),
     locks: branch ? locksByBranch(here)[branch] || [] : [], // this lane's own claims
     pr: includePr && branch ? safePr(mainRoot, branch) : null,
-    lastCommit: branch ? lastCommit(mainRoot, branch) : null,
-    ageDays: branch ? daysSince((lastCommit(mainRoot, branch) || {}).date, Date.now()) : null,
+    lastCommit: lc,
+    ageDays: lc ? daysSince(lc.date, Date.now()) : null,
   };
 }
 

--- a/src/mcp/collect.js
+++ b/src/mcp/collect.js
@@ -19,6 +19,9 @@ const { findOpenPrForBranch, listOpenPrsForRepo } = require('../pr');
 
 const PROTECTED_BRANCHES = new Set(['main', 'master', 'dev']);
 const LOCK_FILE_RELATIVE = path.join('.omx', 'state', 'agent-file-locks.json');
+// A lane older than this (days since last commit), with no open PR and no
+// uncommitted work, is flagged `stale: true` — a candidate for cleanup.
+const STALE_DAYS = Number(process.env.GUARDEX_MCP_STALE_DAYS) || 14;
 
 function git(repoRoot, args) {
   // Bounded: a hung git call must not stall the whole MCP request past the
@@ -189,16 +192,27 @@ function indexPrsByBranch(prs) {
   return map;
 }
 
-// One gh call per repo -> a branch->PR map. Best-effort (never throws).
+// One gh call per repo -> { map: branch->PR, error }. Best-effort (never throws).
+// `error` is set when the lookup itself failed (gh missing/unauthed/offline),
+// distinct from a successful lookup that found no open PRs.
 function prMapForRepo(mainRoot) {
   try {
-    return indexPrsByBranch(listOpenPrsForRepo(mainRoot));
-  } catch {
-    return {};
+    const { prs, error } = listOpenPrsForRepo(mainRoot);
+    return { map: indexPrsByBranch(prs), error: error || null };
+  } catch (err) {
+    return { map: {}, error: String((err && err.message) || err) };
   }
 }
 
-function buildAgentRecord(mainRoot, wt, locks, prMap) {
+// Whole days since an ISO timestamp, or null. Pure (now injected) for testing.
+function daysSince(iso, nowMs) {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return null;
+  return Math.floor((nowMs - t) / 86400000);
+}
+
+function buildAgentRecord(mainRoot, wt, locks, prInfo, nowMs) {
   const branch = wt.branch;
   const record = {
     repo: repoName(mainRoot),
@@ -212,8 +226,15 @@ function buildAgentRecord(mainRoot, wt, locks, prMap) {
     dirty: dirtyFiles(wt.path),
     locks,
     lastCommit: lastCommit(mainRoot, branch),
-    pr: prMap ? prMap[branch] || null : null,
+    pr: prInfo ? prInfo.map[branch] || null : null,
+    prLookupError: prInfo ? prInfo.error : null,
   };
+  // Stale = old, no open PR, no uncommitted work — a safe prune candidate.
+  record.ageDays = record.lastCommit ? daysSince(record.lastCommit.date, nowMs) : null;
+  record.stale = record.ageDays != null
+    && record.ageDays > STALE_DAYS
+    && !record.pr
+    && record.dirty.length === 0;
   if (wt.isPrimary) {
     record.warning =
       'on the PRIMARY checkout, not an isolated worktree — edits here risk auto-stash/revert when another lane switches branches. Use `gx branch start`.';
@@ -235,12 +256,13 @@ function collectRepoAgents(repoPath, { includePrs = true } = {}) {
   const lanes = listWorktrees(mainRoot).filter(isAgentLane);
   if (lanes.length === 0) return []; // no lanes -> no gh call for this repo
   // ONE gh call for the whole repo, only when there is at least one lane.
-  const prMap = includePrs ? prMapForRepo(mainRoot) : null;
+  const prInfo = includePrs ? prMapForRepo(mainRoot) : null;
+  const nowMs = Date.now();
   return lanes.map((wt) => {
     // Each worktree owns its OWN lock file; a lane's locks are the entries in
     // its own worktree keyed to its branch.
     const locks = locksByBranch(wt.path)[wt.branch] || [];
-    return buildAgentRecord(mainRoot, wt, locks, prMap);
+    return buildAgentRecord(mainRoot, wt, locks, prInfo, nowMs);
   });
 }
 
@@ -325,6 +347,7 @@ function myContext({ cwd = process.cwd(), includePr = true } = {}) {
     locks: branch ? locksByBranch(here)[branch] || [] : [], // this lane's own claims
     pr: includePr && branch ? safePr(mainRoot, branch) : null,
     lastCommit: branch ? lastCommit(mainRoot, branch) : null,
+    ageDays: branch ? daysSince((lastCommit(mainRoot, branch) || {}).date, Date.now()) : null,
   };
 }
 
@@ -335,6 +358,8 @@ module.exports = {
   whoOwns,
   myContext,
   indexPrsByBranch,
+  daysSince,
+  STALE_DAYS,
   listWorktrees,
   locksByBranch,
   parseAgentName,

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -19,7 +19,7 @@ const TOOLS = [
   {
     name: 'list_agents',
     description:
-      'List every active agent lane across all discovered repos: repo, branch, worktree, task, dirty (files changed RIGHT NOW), held file locks, last commit, the PR it is shipping, and warnings — e.g. a lane editing the primary checkout (the harness should act on that warning by moving to `gx branch start`). Use this to see who is working on what before you start. Read-only.',
+      'List every active agent lane across all discovered repos: repo, branch, worktree, task, dirty (files changed RIGHT NOW), held file locks, last commit, ageDays, the PR it is shipping (with prLookupError set when the gh lookup itself failed, vs no open PR), stale (old + no PR + clean = a prune candidate), and warnings — e.g. a lane editing the primary checkout (the harness should act on that warning by moving to `gx branch start`). Use this to see who is working on what before you start. Read-only.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/pr.js
+++ b/src/pr.js
@@ -98,8 +98,9 @@ function findLatestPrForBranch(repoRoot, branch) {
 /**
  * List ALL open PRs for the repo on origin in a single gh call, so callers can
  * correlate many branches to their PRs without one gh round-trip per branch.
- * Best-effort: returns [] when gh is missing / unauthenticated / offline
- * (never throws), so a cross-repo scan degrades gracefully.
+ * Best-effort: never throws. Returns `{ prs, error }` so callers can tell a
+ * genuine "no open PRs" (`error: null`) from a failed lookup (gh missing /
+ * unauthenticated / offline → `error` set, `prs: []`).
  * NB: `limit` (default 100) bounds correlation COVERAGE, not just payload size —
  * a repo with more than `limit` open PRs may leave some lanes showing pr:null.
  */
@@ -110,8 +111,9 @@ function listOpenPrsForRepo(repoRoot, { limit = 100 } = {}) {
     '--json', 'number,url,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefName,baseRefName,title',
     '--limit', String(limit),
   ]);
-  if (!result.ok || !Array.isArray(result.data)) return [];
-  return result.data;
+  if (!result.ok) return { prs: [], error: result.error || 'gh pr list failed' };
+  if (!Array.isArray(result.data)) return { prs: [], error: null };
+  return { prs: result.data, error: null };
 }
 
 function pushBranch(repoRoot, branch, { setUpstream = true } = {}) {

--- a/test/mcp-collect.test.js
+++ b/test/mcp-collect.test.js
@@ -139,6 +139,76 @@ test('indexPrsByBranch keys a gh pr-list array by branch and slims the payload',
   assert.deepEqual(collect.indexPrsByBranch(null), {}, 'null input -> empty map');
 });
 
+test('daysSince computes whole-day age and tolerates bad input', () => {
+  const now = Date.parse('2026-06-15T00:00:00Z');
+  assert.equal(collect.daysSince('2026-06-01T00:00:00Z', now), 14);
+  assert.equal(collect.daysSince('2026-06-15T00:00:00Z', now), 0);
+  assert.equal(collect.daysSince(null, now), null);
+  assert.equal(collect.daysSince('not-a-date', now), null);
+});
+
+test('an old lane (no PR, clean) is flagged stale; a fresh lane is not', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gxmcp-stale-'));
+  const main = path.join(root, 'mainrepo');
+  fs.mkdirSync(main);
+  const g = (args, env = {}) => {
+    const r = cp.spawnSync('git', ['-c', 'core.hooksPath=/dev/null', ...args], {
+      cwd: main, encoding: 'utf8', env: { ...process.env, ...env },
+    });
+    if (r.status !== 0) throw new Error(`git ${args.join(' ')}: ${r.stderr}`);
+    return r.stdout;
+  };
+  g(['init', '-q', '-b', 'main']);
+  g(['config', 'user.email', 't@e.com']);
+  g(['config', 'user.name', 'T']);
+  g(['config', 'commit.gpgsign', 'false']);
+  fs.writeFileSync(path.join(main, 'README.md'), 'hi\n');
+  g(['add', '.']);
+  const oldDate = '2026-01-01T00:00:00'; // ~5 months before "now" => well past STALE_DAYS
+  g(['commit', '-q', '-m', 'seed'], { GIT_AUTHOR_DATE: oldDate, GIT_COMMITTER_DATE: oldDate });
+  // old lane: points at the old seed commit
+  g(['worktree', 'add', '-q', '-b', 'agent/old/x', path.join(root, 'wt-old')]);
+  // fresh lane: a brand-new commit
+  g(['worktree', 'add', '-q', '-b', 'agent/new/y', path.join(root, 'wt-new')]);
+  cp.spawnSync('git', ['-c', 'core.hooksPath=/dev/null', 'commit', '--allow-empty', '-q', '-m', 'fresh'], {
+    cwd: path.join(root, 'wt-new'), encoding: 'utf8',
+  });
+  try {
+    const agents = collect.collectRepoAgents(main, { includePrs: false });
+    const old = agents.find((a) => a.branch === 'agent/old/x');
+    const fresh = agents.find((a) => a.branch === 'agent/new/y');
+    assert.ok(old.ageDays > collect.STALE_DAYS, `old lane ageDays=${old.ageDays} should exceed ${collect.STALE_DAYS}`);
+    assert.equal(old.stale, true, 'old + no PR + clean => stale');
+    assert.equal(old.prLookupError, null, 'includePrs:false => no lookup error');
+    assert.equal(fresh.stale, false, 'fresh lane is not stale');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a failed PR lookup surfaces as prLookupError (distinct from "no open PR")', () => {
+  // A repo with no GitHub remote -> `gh pr list` cannot succeed -> error is set.
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gxmcp-prerr-'));
+  const g = (args) => cp.spawnSync('git', ['-c', 'core.hooksPath=/dev/null', ...args], { cwd: root, encoding: 'utf8' });
+  g(['init', '-q', '-b', 'main']);
+  g(['config', 'user.email', 't@e.com']);
+  g(['config', 'user.name', 'T']);
+  g(['config', 'commit.gpgsign', 'false']);
+  fs.writeFileSync(path.join(root, 'f'), 'x');
+  g(['add', '.']);
+  g(['commit', '-q', '-m', 's']);
+  g(['worktree', 'add', '-q', '-b', 'agent/p/q', path.join(root, 'wt')]);
+  try {
+    const agents = collect.collectRepoAgents(root, { includePrs: true });
+    assert.equal(agents.length, 1);
+    assert.equal(typeof agents[0].prLookupError, 'string', 'gh failure surfaces as a prLookupError string');
+    assert.ok(agents[0].prLookupError.length > 0);
+    assert.equal(agents[0].pr, null);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('an agent editing on the PRIMARY checkout is surfaced with a warning', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gxmcp-primary-'));
   try {


### PR DESCRIPTION
Closes the two gx mcp review follow-ups: list_agents records now carry `prLookupError` (a failed gh lookup is distinct from 'no open PR'), `ageDays`, and `stale` (old + no open PR + clean = a prune candidate; threshold GUARDEX_MCP_STALE_DAYS, default 14). `pr.listOpenPrsForRepo` returns { prs, error }.

Gate: independent review clean (no CRITICAL/HIGH/MEDIUM); failing-test set byte-identical to base (22=22, zero NEW). Baseline-red repo, manual gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)