### PR TITLE
chore(release): bump version to 7.1.0

### DIFF
--- a/openspec/changes/agent-claude-bump-version-to-7-1-0-for-agent-coordina-2026-06-05-17-23/.openspec.yaml
+++ b/openspec/changes/agent-claude-bump-version-to-7-1-0-for-agent-coordina-2026-06-05-17-23/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/agent-claude-bump-version-to-7-1-0-for-agent-coordina-2026-06-05-17-23/notes.md
+++ b/openspec/changes/agent-claude-bump-version-to-7-1-0-for-agent-coordina-2026-06-05-17-23/notes.md
@@ -1,0 +1,24 @@
+# Release: @imdeadpool/guardex 7.1.0 — Cross-repo agent coordination
+
+Version bump 7.0.43 -> 7.1.0 (minor; new `gx mcp` feature + behavior-default
+changes, all backward-compatible / overridable). Cuts a release covering PRs
+#626-#633.
+
+## Why minor
+Multiple `feat:` additions since the last tag (v7.0.42): the `gx mcp` agent
+radar, `gx claude install` MCP auto-registration, the any-non-protected-branch
+policy, and the T1 default tier. No removals; every default change is overridable.
+
+## Included (since v7.0.42)
+- feat: any non-protected branch is agent-managed (#626)
+- perf: protected-branch advisor dedup + guard-message consistency (#627)
+- feat: `gx mcp` cross-repo read-only agent radar (#628)
+- feat: `gx claude install` auto-registers the gx MCP server in `.mcp.json` (#629)
+- perf/feat: batch PR lookups, PRs on by default in list_agents (#630)
+- perf: preflight quiet by default + fix single-failing-step false pass (#631)
+- feat: default `gx branch start` tier T1, not T3 (#632)
+- feat: gx mcp stale-lane detection + pr_lookup_error field (#633)
+
+## Release mechanics
+Manual bump + manual `npm publish` this cycle (bypasses release-please for this
+release). GitHub release `v7.1.0` published with full English notes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "7.0.43",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@imdeadpool/guardex",
-      "version": "7.0.43",
+      "version": "7.1.0",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imdeadpool/guardex",
-  "version": "7.0.43",
+  "version": "7.1.0",
   "description": "Guardian T-Rex for your multi-agent repo. Isolated worktrees, file locks, and PR-only merges stop parallel Codex & Claude agents from overwriting each other's work. Auto-wires Oh My Codex, Oh My Claude, OpenSpec, and Caveman.",
   "license": "MIT",
   "preferGlobal": true,


### PR DESCRIPTION
Cross-repo agent coordination release. Minor bump 7.0.43 -> 7.1.0 (new `gx mcp` feature + backward-compatible default changes), covering #626-#633. Version-only change (package.json + lock + release notes), no code/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)