### PR TITLE
fix(locks): see claims written by a submodule under a linked worktree

### DIFF
--- a/templates/scripts/agent-file-locks.py
+++ b/templates/scripts/agent-file-locks.py
@@ -210,8 +210,13 @@ def staged_changes(repo_root: Path) -> list[tuple[str, str]]:
 
 
 def list_worktree_roots(repo_root: Path) -> list[Path]:
-    """Every worktree path for this repo (porcelain). Falls back to [repo_root]
-    when git cannot enumerate, so single-checkout behavior is unchanged."""
+    """Every worktree path for this repo (porcelain), ALWAYS including the
+    caller's own repo_root. Submodules checked out inside a LINKED worktree
+    report their gitdir (<parent>/.git/worktrees/<wt>/modules/<sub>) as the
+    worktree path, not the actual working tree — repo_root (resolved via
+    --show-toplevel) is where claims are written, so it must be in the list
+    or claim/validate/status never see this checkout's own lock file. Falls
+    back to [repo_root] when git cannot enumerate."""
     try:
         out = run_git(['worktree', 'list', '--porcelain'], cwd=repo_root)
     except LockError:
@@ -221,7 +226,9 @@ def list_worktree_roots(repo_root: Path) -> list[Path]:
     for line in out.splitlines():
         if line.startswith('worktree '):
             roots.append(Path(line[len('worktree '):].strip()).resolve())
-    return roots or [repo_root]
+    if repo_root not in roots:
+        roots.append(repo_root)
+    return roots
 
 
 def load_all_locks(repo_root: Path) -> dict[str, list[dict[str, Any]]]:
@@ -230,16 +237,7 @@ def load_all_locks(repo_root: Path) -> dict[str, list[dict[str, Any]]]:
     disk, so a file's full ownership is only visible by reading them all. With a
     single worktree this is exactly that worktree's own locks (unchanged)."""
     merged: dict[str, list[dict[str, Any]]] = {}
-    roots = list_worktree_roots(repo_root)
-    # Submodules checked out inside a LINKED worktree report their gitdir
-    # (<parent>/.git/worktrees/<wt>/modules/<sub>) as the worktree path in
-    # `git worktree list`, not the actual working tree. The caller's own
-    # repo_root (resolved via --show-toplevel) is the real working tree where
-    # claims are written, so always include it — otherwise validate never sees
-    # the claims it itself just recorded.
-    if repo_root not in roots:
-        roots.append(repo_root)
-    for root in roots:
+    for root in list_worktree_roots(repo_root):
         try:
             state = load_state(root)
         except LockError:

--- a/templates/scripts/agent-file-locks.py
+++ b/templates/scripts/agent-file-locks.py
@@ -230,7 +230,16 @@ def load_all_locks(repo_root: Path) -> dict[str, list[dict[str, Any]]]:
     disk, so a file's full ownership is only visible by reading them all. With a
     single worktree this is exactly that worktree's own locks (unchanged)."""
     merged: dict[str, list[dict[str, Any]]] = {}
-    for root in list_worktree_roots(repo_root):
+    roots = list_worktree_roots(repo_root)
+    # Submodules checked out inside a LINKED worktree report their gitdir
+    # (<parent>/.git/worktrees/<wt>/modules/<sub>) as the worktree path in
+    # `git worktree list`, not the actual working tree. The caller's own
+    # repo_root (resolved via --show-toplevel) is the real working tree where
+    # claims are written, so always include it — otherwise validate never sees
+    # the claims it itself just recorded.
+    if repo_root not in roots:
+        roots.append(repo_root)
+    for root in roots:
         try:
             state = load_state(root)
         except LockError:

--- a/test/agent-file-locks.test.js
+++ b/test/agent-file-locks.test.js
@@ -168,6 +168,36 @@ defineSpawnSuite('agent-file-locks cross-worktree (G2)', () => {
     assert.match(v1.stderr, /another owner/);
   });
 
+  test('claims in a submodule under a LINKED worktree are visible to validate (gitdir-root quirk)', () => {
+    // A submodule checked out inside a linked worktree reports its gitdir
+    // (<parent>/.git/worktrees/<wt>/modules/<sub>) as the worktree path in
+    // `git worktree list`, so load_all_locks used to miss the REAL working
+    // tree's lock file — validate rejected claims it had just recorded.
+    const subSrc = makeRepo();
+    const parent = makeRepo();
+    assert.equal(
+      runHumanCmd('git', ['-c', 'protocol.file.allow=always', 'submodule', 'add', subSrc, 'sub'], parent).status,
+      0,
+      'submodule add must succeed',
+    );
+    assert.equal(runHumanCmd('git', ['commit', '-m', 'add submodule'], parent).status, 0);
+
+    const wtSub = path.join(parent, '..', 'wt-sub');
+    assert.equal(runHumanCmd('git', ['worktree', 'add', '-q', '-b', 'agent/sub/lane', wtSub], parent).status, 0);
+    assert.equal(
+      runHumanCmd('git', ['-c', 'protocol.file.allow=always', 'submodule', 'update', '--init'], wtSub).status,
+      0,
+      'submodule init inside the linked worktree must succeed',
+    );
+
+    const subWt = path.join(wtSub, 'sub');
+    writeFile(subWt, 'sub-file.txt');
+    assert.equal(locksAt(subWt, ['claim', '--branch', 'agent/sub/lane', 'sub-file.txt']).status, 0);
+
+    const v = locksAt(subWt, ['validate', '--branch', 'agent/sub/lane', 'sub-file.txt']);
+    assert.equal(v.status, 0, `validate must see the claim it just wrote: ${v.stderr}`);
+  });
+
   test('a lane can still claim + commit a file no other worktree owns', () => {
     const repoDir = makeRepo();
     writeFile(repoDir, 'mine.txt');


### PR DESCRIPTION
## Bug
`git worktree list` egy LINKED worktree-ben lévő submodule-ból a gitdirt (`<parent>/.git/worktrees/<wt>/modules/<sub>`) adja vissza worktree útként, nem a tényleges working tree-t. A `load_all_locks` csak ezekből a rootokból olvasott, így a `validate` nem látta a saját, frissen felvett claimeket — az agent commitok ilyen submodule-okban mindig blokkolódtak (ma egy LIFTEDV2 session-ben kézzel kellett a lock-fájlt a gitdir alá tükrözni).

## Fix
A hívó feloldott `repo_root`-ja mindig bekerül a rootok listájába (1 guardolt append a `load_all_locks`-ban).

## Teszt
Új regressziós teszt (parent + submodule + linked worktree, claim→validate a worktree submodule-jából): fix nélkül FAIL, fixszel a teljes suite 11/11 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)