### PR TITLE
fix(finish): use repo_root for agent_worktree_root in submodule repos

### DIFF
--- a/templates/scripts/agent-branch-finish.sh
+++ b/templates/scripts/agent-branch-finish.sh
@@ -491,7 +491,7 @@ stored_worktree_root_rel="$(git -C "$repo_root" config --get "branch.${SOURCE_BR
 if [[ -z "$stored_worktree_root_rel" ]]; then
   stored_worktree_root_rel=".omx/agent-worktrees"
 fi
-agent_worktree_root="${repo_common_root}/${stored_worktree_root_rel}"
+agent_worktree_root="${repo_root}/${stored_worktree_root_rel}"
 runtime_state_root_rel="$(dirname "$stored_worktree_root_rel")"
 temp_worktree_root="${repo_common_root}/${runtime_state_root_rel}/.tmp-worktrees"
 

--- a/templates/scripts/agent-file-locks.py
+++ b/templates/scripts/agent-file-locks.py
@@ -237,16 +237,7 @@ def load_all_locks(repo_root: Path) -> dict[str, list[dict[str, Any]]]:
     disk, so a file's full ownership is only visible by reading them all. With a
     single worktree this is exactly that worktree's own locks (unchanged)."""
     merged: dict[str, list[dict[str, Any]]] = {}
-    roots = list_worktree_roots(repo_root)
-    # Submodules checked out inside a LINKED worktree report their gitdir
-    # (<parent>/.git/worktrees/<wt>/modules/<sub>) as the worktree path in
-    # `git worktree list`, not the actual working tree. The caller's own
-    # repo_root (resolved via --show-toplevel) is the real working tree where
-    # claims are written, so always include it — otherwise validate never sees
-    # the claims it itself just recorded.
-    if repo_root not in roots:
-        roots.append(repo_root)
-    for root in roots:
+    for root in list_worktree_roots(repo_root):
         try:
             state = load_state(root)
         except LockError:

--- a/templates/scripts/agent-file-locks.py
+++ b/templates/scripts/agent-file-locks.py
@@ -237,7 +237,16 @@ def load_all_locks(repo_root: Path) -> dict[str, list[dict[str, Any]]]:
     disk, so a file's full ownership is only visible by reading them all. With a
     single worktree this is exactly that worktree's own locks (unchanged)."""
     merged: dict[str, list[dict[str, Any]]] = {}
-    for root in list_worktree_roots(repo_root):
+    roots = list_worktree_roots(repo_root)
+    # Submodules checked out inside a LINKED worktree report their gitdir
+    # (<parent>/.git/worktrees/<wt>/modules/<sub>) as the worktree path in
+    # `git worktree list`, not the actual working tree. The caller's own
+    # repo_root (resolved via --show-toplevel) is the real working tree where
+    # claims are written, so always include it — otherwise validate never sees
+    # the claims it itself just recorded.
+    if repo_root not in roots:
+        roots.append(repo_root)
+    for root in roots:
         try:
             state = load_state(root)
         except LockError:


### PR DESCRIPTION
Automated by gx branch finish (PR flow).