### PR TITLE
chore: Biome lint + coverage CI and frontend SEO/GEO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,11 @@ jobs:
       - name: Install
         run: npm install --ignore-scripts
 
-      - name: Unit tests
-        run: npm test
+      - name: Lint (Biome)
+        run: npm run lint
+
+      - name: Unit tests (with coverage)
+        run: npm run test:coverage
 
       - name: Static check CLI entrypoint
         run: node --check bin/multiagent-safety.js

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "include": ["bin/**/*.js", "src/**/*.js", "scripts/**/*.js", "test/**/*.js"],
+    "ignore": [
+      "**/node_modules/**",
+      "**/.next/**",
+      "frontend/**",
+      "templates/**",
+      "examples/**",
+      "**/*.min.js"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always",
+      "trailingCommas": "none"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "noForEach": "off",
+        "useOptionalChain": "off",
+        "noMultipleSpacesInRegularExpressionLiterals": "off",
+        "useRegexLiterals": "off"
+      },
+      "correctness": {
+        "noUnnecessaryContinue": "off"
+      },
+      "performance": {
+        "noDelete": "off"
+      },
+      "style": {
+        "noUselessElse": "off",
+        "useNodejsImportProtocol": "off",
+        "useTemplate": "off",
+        "noUnusedTemplateLiteral": "off",
+        "useConst": "off",
+        "useDefaultParameterLast": "off",
+        "useNumberNamespace": "off",
+        "noArguments": "off"
+      },
+      "suspicious": {
+        "noExplicitAny": "off",
+        "noAssignInExpressions": "off",
+        "noRedundantUseStrict": "off",
+        "noControlCharactersInRegex": "off"
+      }
+    }
+  }
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,9 +1,112 @@
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import './globals.css'
 
+// Canonical site origin. Override per-deployment with NEXT_PUBLIC_SITE_URL
+// (e.g. the production domain). Falls back to the project home so OpenGraph
+// and canonical URLs always resolve to a real, reachable page.
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://github.com/recodeee/gitguardex'
+const OG_IMAGE = 'https://raw.githubusercontent.com/recodeee/gitguardex/main/logo.png'
+
+const TITLE = 'GitGuardex — Guardian T-Rex for Multi-Agent Repos'
+const DESCRIPTION =
+  'GitGuardex gives parallel Codex, Claude, and human teammates isolated git worktrees, file locks, and PR-only merges so concurrent AI agents never overwrite each other’s work.'
+
 export const metadata: Metadata = {
-  title: 'GitGuardex | How It Works',
-  description: 'A workflow-style GitGuardex onboarding preview built with Next.js.'
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: TITLE,
+    template: '%s | GitGuardex'
+  },
+  description: DESCRIPTION,
+  applicationName: 'GitGuardex',
+  authors: [{ name: 'recodee', url: 'https://github.com/recodeee' }],
+  creator: 'recodee',
+  publisher: 'recodee',
+  category: 'developer tools',
+  keywords: [
+    'GitGuardex',
+    'guardex',
+    'multi-agent',
+    'AI agents',
+    'Codex',
+    'Claude Code',
+    'git worktree',
+    'file locks',
+    'branch guard',
+    'agent safety',
+    'pull request workflow',
+    'OpenSpec',
+    'developer tools',
+    'CLI'
+  ],
+  alternates: {
+    canonical: '/'
+  },
+  openGraph: {
+    type: 'website',
+    siteName: 'GitGuardex',
+    title: TITLE,
+    description: DESCRIPTION,
+    url: SITE_URL,
+    images: [
+      {
+        url: OG_IMAGE,
+        width: 1200,
+        height: 630,
+        alt: 'GitGuardex — guardian T-Rex for multi-agent repos'
+      }
+    ]
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: TITLE,
+    description: DESCRIPTION,
+    images: [OG_IMAGE]
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+      'max-video-preview': -1
+    }
+  }
+}
+
+export const viewport: Viewport = {
+  themeColor: '#0b0e14',
+  colorScheme: 'dark light'
+}
+
+// Structured data so search engines and generative engines (GEO) can model
+// GitGuardex as an installable developer tool with a clear description.
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'GitGuardex',
+  alternateName: 'guardex',
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'macOS, Linux, Windows',
+  description: DESCRIPTION,
+  url: SITE_URL,
+  image: OG_IMAGE,
+  license: 'https://opensource.org/licenses/MIT',
+  softwareHelp: 'https://github.com/recodeee/gitguardex#readme',
+  installUrl: 'https://www.npmjs.com/package/@imdeadpool/guardex',
+  downloadUrl: 'https://www.npmjs.com/package/@imdeadpool/guardex',
+  author: {
+    '@type': 'Organization',
+    name: 'recodee',
+    url: 'https://github.com/recodeee'
+  },
+  offers: {
+    '@type': 'Offer',
+    price: '0',
+    priceCurrency: 'USD'
+  }
 }
 
 export default function RootLayout({
@@ -13,7 +116,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <script
+          type="application/ld+json"
+          // biome-ignore lint: structured-data JSON-LD injection is intentional
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+        {children}
+      </body>
     </html>
   )
 }

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next'
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://github.com/recodeee/gitguardex'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/'
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL
+  }
+}

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next'
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://github.com/recodeee/gitguardex'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date()
+  return [
+    {
+      url: SITE_URL,
+      lastModified: now,
+      changeFrequency: 'weekly',
+      priority: 1
+    }
+  ]
+}

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -1,0 +1,43 @@
+# GitGuardex
+
+> Guardian T-Rex for multi-agent repos. GitGuardex gives parallel Codex,
+> Claude, and human teammates isolated git worktrees, file locks, and
+> PR-only merges so concurrent AI agents never overwrite each other's work.
+
+GitGuardex (CLI commands: `gx`, `guardex`, `gitguardex`) is an MIT-licensed
+Node.js tool published to npm as `@imdeadpool/guardex`. It auto-wires Oh My
+Codex, Oh My Claude, OpenSpec, and Caveman into a repository.
+
+## What it does
+
+- **Isolated worktrees** — every agent task runs on its own `agent/*` branch
+  in a dedicated git worktree, never on the protected base (`main`/`dev`).
+- **File locks** — agents claim files before editing (`gx locks claim`) so two
+  agents cannot edit the same path concurrently.
+- **PR-only merges** — completed work lands through pull requests via
+  `gx branch finish --via-pr --wait-for-merge --cleanup`, never direct pushes.
+- **Multi-agent cockpit** — a tmux/kitty-style cockpit (`gx`) shows live agent
+  status, ownership, and conflicts across the repo.
+
+## Install
+
+```bash
+npm i -g @imdeadpool/guardex
+cd /path/to/your-repo
+gx setup
+```
+
+## Key commands
+
+- `gx setup` — install hooks, state, and OMX / OpenSpec / Caveman wiring.
+- `gx branch start "<task>" "<agent>"` — open an isolated worktree.
+- `gx locks claim --branch "<branch>" <file...>` — claim files before editing.
+- `gx branch finish --via-pr --wait-for-merge --cleanup` — commit, push, PR,
+  merge, and clean up the sandbox in one shot.
+- `gx status` / `gx doctor` — inspect and repair repo guardrails.
+
+## Links
+
+- Source: https://github.com/recodeee/gitguardex
+- npm: https://www.npmjs.com/package/@imdeadpool/guardex
+- License: MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "multiagent-safety": "bin/multiagent-safety.js"
       },
       "devDependencies": {
+        "@biomejs/biome": "1.9.4",
         "fast-check": "3.23.2"
       },
       "engines": {
@@ -26,6 +27,170 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/recodeecom"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "1.9.4",
+        "@biomejs/cli-darwin-x64": "1.9.4",
+        "@biomejs/cli-linux-arm64": "1.9.4",
+        "@biomejs/cli-linux-arm64-musl": "1.9.4",
+        "@biomejs/cli-linux-x64": "1.9.4",
+        "@biomejs/cli-linux-x64-musl": "1.9.4",
+        "@biomejs/cli-win32-arm64": "1.9.4",
+        "@biomejs/cli-win32-x64": "1.9.4"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/fast-check": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   },
   "scripts": {
     "test": "node --test test/*.test.js",
+    "test:coverage": "node --test --experimental-test-coverage test/*.test.js",
+    "lint": "biome lint bin src scripts test",
+    "format": "biome format --write bin src scripts test",
+    "format:check": "biome format bin src scripts test",
     "prepublishOnly": "node scripts/prepublish-bump-version.js",
     "agent:codex": "bash ./scripts/codex-agent.sh",
     "agent:branch:start": "bash ./scripts/agent-branch-start.sh",
@@ -56,7 +60,17 @@
     "git-hooks",
     "branch-guard",
     "agent-safety",
-    "codex"
+    "codex",
+    "claude",
+    "claude-code",
+    "ai-agents",
+    "git-worktree",
+    "file-locks",
+    "worktree",
+    "openspec",
+    "agent-orchestration",
+    "pull-request",
+    "cli"
   ],
   "author": "recodeecom",
   "repository": {
@@ -72,6 +86,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@biomejs/biome": "1.9.4",
     "fast-check": "3.23.2"
   },
   "dependencies": {


### PR DESCRIPTION
## What

Implements three of the repo-improvement suggestions: **lint guardrails**, **test coverage in CI**, and **frontend SEO/GEO**.

### CLI guardrails
- **Biome 1.9.4** added with a *green-baseline* config: all `recommended` correctness/suspicious rules stay **on**, while the rules currently violated by the existing 85 files are disabled. This is a ratchet — CI catches **new** issues without a risky 85-file reformat in a live multi-agent repo. Teams can later run `npm run format` and re-enable rules incrementally.
- New scripts: `lint`, `format`, `format:check`, `test:coverage`.
- CI (`ci.yml`) now runs a **Lint (Biome)** step and switches unit tests to **`test:coverage`** (`node --experimental-test-coverage`). Kept the repo's budget-friendly single-Node PR design intact (no matrix added — that stays in the weekly `ci-full.yml`).
- Expanded npm `keywords` for package discoverability.

### Frontend SEO/GEO (Next.js App Router)
- `app/layout.tsx`: rich metadata — `metadataBase`, canonical, OpenGraph, Twitter card, robots directives, `viewport`, and **`SoftwareApplication` JSON-LD** structured data.
- `app/robots.ts` + `app/sitemap.ts` metadata routes.
- `public/llms.txt` for **generative-engine optimization (GEO)** — gives AI crawlers a clean project summary.
- Site origin is overridable per-deployment via `NEXT_PUBLIC_SITE_URL` (defaults to the GitHub repo so URLs always resolve).

## Verification
- `npm run lint` → clean (171 files checked).
- `npx tsc --noEmit` (frontend) → clean.
- Coverage flag verified working; reporting only, no thresholds, so it doesn't change pass/fail.
- ℹ️ 22 tests fail **in this sandbox only** — confirmed identical on the clean tree before any change (environment-specific: worktree/tmux/git-env deps). CI on GitHub Actions is green on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Qyz9J4TivR9kJeAeETSUw

---
_Generated by [Claude Code](https://claude.ai/code/session_015Qyz9J4TivR9kJeAeETSUw)_