### PR TITLE
feat(cli): add `gx onboard` guided first-run tour

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@
 ```bash
 npm i -g @imdeadpool/guardex
 cd /path/to/your-repo
-gx setup   # hooks, state, OMX / OpenSpec / caveman wiring — one shot
+gx setup     # hooks, state, OMX / OpenSpec / caveman wiring — one shot
+gx onboard   # optional: 2-minute guided tour — where you are + the exact next command
 ```
 
 <p align="center">
@@ -224,6 +225,7 @@ the compact layout everywhere.
 
 | command | does |
 | --- | --- |
+| `gx onboard` | Guided first-run tour: where you are + the exact next command (alias: `gx welcome`). |
 | `gx status` | Health check (the default when you type `gx`). |
 | `gx status --strict` | Exit non-zero on findings. |
 | `gx setup` | Full bootstrap. |

--- a/src/cli/commands/onboard.js
+++ b/src/cli/commands/onboard.js
@@ -1,0 +1,293 @@
+// `gx onboard` — guided first-run experience for a new GitGuardex user.
+//
+// It does three things and nothing destructive:
+//   1. reflects what is already wired in the current repo (guardrails,
+//      companions, origin) so a newcomer knows their real starting point,
+//   2. teaches the load-bearing model (isolated lanes / file locks / PR-only)
+//      and the exact first-task command sequence,
+//   3. drops a tiny first-run marker so `gx setup` only nudges toward the tour
+//      once.
+//
+// The marker lives under the repo's runtime state dir (gitignored), so it is
+// per-repo and never committed.
+
+const {
+  fs,
+  path,
+  TOOL_NAME,
+  SHORT_TOOL_NAME,
+  packageJson,
+} = require('../../context');
+const {
+  resolveRepoRoot,
+  isGitRepo,
+  currentBranchName,
+  repoHasHeadCommit,
+  hasOriginRemote,
+} = require('../../git');
+const { colorize, statusDot, supportsAnsiColors } = require('../../output');
+const { collectServicesSnapshot } = require('./status');
+
+const ONBOARD_MARKER_RELATIVE = path.join('.omx', 'state', 'onboarded.json');
+const MANAGED_BLOCK_MARKER = 'multiagent-safety:START';
+
+function onboardMarkerPath(repoRoot) {
+  return path.join(repoRoot, ONBOARD_MARKER_RELATIVE);
+}
+
+// hasCompletedOnboarding is intentionally cheap and forgiving: any unreadable
+// state simply means "not onboarded yet" so a newcomer still gets the nudge.
+function hasCompletedOnboarding(repoRoot) {
+  try {
+    return fs.existsSync(onboardMarkerPath(repoRoot));
+  } catch {
+    return false;
+  }
+}
+
+function markOnboardingComplete(repoRoot) {
+  try {
+    const markerPath = onboardMarkerPath(repoRoot);
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+    fs.writeFileSync(
+      markerPath,
+      `${JSON.stringify({ version: packageJson.version, at: new Date().toISOString() }, null, 2)}\n`,
+      'utf8',
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resetOnboarding(repoRoot) {
+  try {
+    fs.rmSync(onboardMarkerPath(repoRoot), { force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// guardrailsInstalled treats the managed AGENTS.md/CLAUDE.md block as the
+// canonical "setup has run here" signal — it is what `gx setup`/`gx doctor`
+// write and is stable across worktrees.
+function guardrailsInstalled(repoRoot) {
+  for (const name of ['AGENTS.md', 'CLAUDE.md']) {
+    try {
+      const contents = fs.readFileSync(path.join(repoRoot, name), 'utf8');
+      if (contents.includes(MANAGED_BLOCK_MARKER)) {
+        return true;
+      }
+    } catch {
+      // missing/unreadable file — keep checking the next candidate.
+    }
+  }
+  return false;
+}
+
+function bold(text) {
+  return supportsAnsiColors() ? colorize(text, '1') : text;
+}
+
+function dim(text) {
+  return supportsAnsiColors() ? colorize(text, '2') : text;
+}
+
+function heading(text) {
+  return supportsAnsiColors() ? colorize(text, '1;36') : text;
+}
+
+function printOnboardHelp() {
+  console.log(
+    `${SHORT_TOOL_NAME} onboard — guided first-run tour.\n` +
+    `  ${SHORT_TOOL_NAME} onboard                 Show where you are + how to start\n` +
+    `  ${SHORT_TOOL_NAME} onboard --target <path> Inspect another repo path\n` +
+    `  ${SHORT_TOOL_NAME} onboard --reset         Clear the first-run marker (re-arms the setup nudge)`,
+  );
+}
+
+function parseOnboardArgs(rawArgs) {
+  const args = Array.isArray(rawArgs) ? rawArgs : [];
+  const options = { target: process.cwd(), reset: false, help: false };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '-h' || arg === '--help') {
+      options.help = true;
+    } else if (arg === '--reset') {
+      options.reset = true;
+    } else if (arg === '--target' || arg === '--current') {
+      if (arg === '--current') {
+        options.target = process.cwd();
+        continue;
+      }
+      const value = args[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error('--target requires a path value');
+      }
+      options.target = value;
+      index += 1;
+    } else if (arg.startsWith('--target=')) {
+      options.target = arg.slice('--target='.length);
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function statusLine(label, status, detail) {
+  const dot = statusDot(status);
+  const tail = detail ? `  ${dim(detail)}` : '';
+  return `  ${dot} ${label.padEnd(12)}${tail}`;
+}
+
+function printWhereYouAre(repoRoot, inRepo) {
+  console.log(heading('WHERE YOU ARE'));
+  if (!inRepo) {
+    console.log(statusLine('repo', 'inactive', 'not a git repo — run from a repo root or pass --target <path>'));
+    return;
+  }
+  const branch = currentBranchName(repoRoot) || '(detached)';
+  const installed = guardrailsInstalled(repoRoot);
+  const hasOrigin = hasOriginRemote(repoRoot);
+  const hasCommit = repoHasHeadCommit(repoRoot);
+
+  console.log(statusLine('repo', 'active', repoRoot));
+  console.log(statusLine('branch', 'active', branch));
+  console.log(
+    installed
+      ? statusLine('guardrails', 'active', 'installed')
+      : statusLine('guardrails', 'inactive', `not yet — run \`${SHORT_TOOL_NAME} setup\``),
+  );
+  console.log(
+    hasOrigin
+      ? statusLine('origin', 'active', 'remote present')
+      : statusLine('origin', 'warning', 'none — finish/merge stay local until you add one'),
+  );
+  if (!hasCommit) {
+    console.log(statusLine('commits', 'warning', 'fresh repo — make a first commit before finishing a lane'));
+  }
+}
+
+function companionNote(service) {
+  if (service.status === 'active') {
+    return '';
+  }
+  if (service.status === 'unknown') {
+    return 'status unknown (is npm on PATH?)';
+  }
+  if (service.required) {
+    return 'required · not on PATH';
+  }
+  return 'optional · not installed';
+}
+
+function printCompanions() {
+  let snapshot;
+  try {
+    snapshot = collectServicesSnapshot();
+  } catch {
+    return;
+  }
+  // requiredSystemTools (gh/rtk) gate PR + finish automation, so flag them as
+  // required rather than letting them read as "optional companions".
+  const requiredNames = new Set(
+    (snapshot.requiredSystemTools || []).map((tool) => tool.displayName || tool.name),
+  );
+  const services = (snapshot.services || [])
+    .filter((service) => service && service.displayName)
+    .map((service) => ({ ...service, required: requiredNames.has(service.displayName) }));
+  if (services.length === 0) {
+    return;
+  }
+  console.log('');
+  console.log(heading('COMPANIONS') + dim('  (all optional except gh/rtk)'));
+  const maxName = services.reduce((max, service) => Math.max(max, service.displayName.length), 0);
+  for (const service of services) {
+    const note = companionNote(service);
+    console.log(`  ${statusDot(service.status)} ${service.displayName.padEnd(maxName + 2)}${note ? dim(note) : ''}`);
+  }
+}
+
+function printHowItWorks() {
+  console.log('');
+  console.log(heading('HOW IT WORKS') + dim('  (30 seconds)'));
+  console.log(`  1. ${bold('Isolated lane')}   — each task gets its own ${bold('agent/*')} branch + worktree`);
+  console.log(`  2. ${bold('File locks')}      — claim files before editing; nobody clobbers them`);
+  console.log(`  3. ${bold('Protected base')}  — main/dev are never edited directly; you merge via PR`);
+}
+
+function printFirstTask(installed) {
+  console.log('');
+  console.log(heading('YOUR FIRST TASK'));
+  const setupMark = installed ? dim('# done ✓') : dim('# one-time: wire hooks + companions');
+  console.log(`  1. ${SHORT_TOOL_NAME} setup                                   ${setupMark}`);
+  console.log(`  2. ${SHORT_TOOL_NAME} branch start "<task>" "<agent>"         ${dim('# isolated lane + worktree')}`);
+  console.log(`  3. ${SHORT_TOOL_NAME} locks claim --branch <branch> <file...> ${dim('# declare what you touch')}`);
+  console.log(`  4. ${dim('<implement + run your tests inside the worktree>')}`);
+  console.log(`  5. ${SHORT_TOOL_NAME} branch finish --via-pr --wait-for-merge --cleanup`);
+}
+
+function printNext(installed) {
+  console.log('');
+  console.log(heading('NEXT'));
+  if (!installed) {
+    console.log(`  › ${SHORT_TOOL_NAME} setup        ${dim('install + verify guardrails in this repo')}`);
+  }
+  console.log(`  › ${SHORT_TOOL_NAME} prompt       ${dim('copy the AI setup checklist for your agent')}`);
+  console.log(`  › ${SHORT_TOOL_NAME} status       ${dim('health check anytime (never modifies files)')}`);
+  console.log(`  › ${SHORT_TOOL_NAME} help         ${dim('full command list')}`);
+}
+
+function onboard(rawArgs) {
+  const options = parseOnboardArgs(rawArgs);
+  if (options.help) {
+    printOnboardHelp();
+    process.exitCode = 0;
+    return;
+  }
+
+  const inRepo = isGitRepo(options.target);
+  const repoRoot = inRepo ? resolveRepoRoot(options.target) : path.resolve(options.target);
+
+  if (options.reset) {
+    const cleared = resetOnboarding(repoRoot);
+    console.log(
+      cleared
+        ? `[${TOOL_NAME}] First-run marker cleared. \`${SHORT_TOOL_NAME} setup\` will nudge the tour again.`
+        : `[${TOOL_NAME}] No first-run marker to clear.`,
+    );
+    process.exitCode = 0;
+    return;
+  }
+
+  const installed = inRepo && guardrailsInstalled(repoRoot);
+
+  console.log('');
+  console.log(`👋  ${bold(`Welcome to GitGuardex v${packageJson.version}`)}`);
+  console.log(`    ${dim('Guardian t-rex for multi-agent repos — many agents, one clean repo.')}`);
+  console.log('');
+
+  printWhereYouAre(repoRoot, inRepo);
+  printCompanions();
+  printHowItWorks();
+  printFirstTask(installed);
+  printNext(installed);
+  console.log('');
+
+  if (inRepo) {
+    markOnboardingComplete(repoRoot);
+  }
+  process.exitCode = 0;
+}
+
+module.exports = {
+  onboard,
+  hasCompletedOnboarding,
+  markOnboardingComplete,
+  resetOnboarding,
+  guardrailsInstalled,
+  onboardMarkerPath,
+  ONBOARD_MARKER_RELATIVE,
+};

--- a/src/cli/commands/setup.js
+++ b/src/cli/commands/setup.js
@@ -17,8 +17,9 @@ const {
 const toolchainModule = require('../../toolchain');
 const doctorModule = require('../../doctor');
 const speckitModule = require('../../speckit');
-const { printAutoFinishSummary } = require('../../output');
+const { printAutoFinishSummary, colorize, supportsAnsiColors } = require('../../output');
 const { printOperations } = require('../../scaffold');
+const { hasCompletedOnboarding } = require('./onboard');
 const { parseSetupArgs } = require('../args');
 const {
   runScanInternal,
@@ -217,6 +218,11 @@ function setup(rawArgs) {
     const repoCount = discoveredRepos.length;
     const suffix = repoCount > 1 ? ` (${repoCount} repos)` : '';
     console.log(`[${TOOL_NAME}] ✅ Setup complete.${suffix}`);
+    // First run in this repo: point newcomers at the guided tour exactly once.
+    if (!hasCompletedOnboarding(topRepoRoot)) {
+      const nudge = `👋 New to GitGuardex? Run \`${SHORT_TOOL_NAME} onboard\` for a 2-minute guided tour.`;
+      console.log(`[${TOOL_NAME}] ${supportsAnsiColors() ? colorize(nudge, '1;36') : nudge}`);
+    }
     console.log(`[${TOOL_NAME}] Copy AI setup prompt with: ${SHORT_TOOL_NAME} prompt`);
     console.log(
       `[${TOOL_NAME}] OpenSpec core workflow: /opsx:propose -> /opsx:apply -> /opsx:archive`,

--- a/src/cli/main.js
+++ b/src/cli/main.js
@@ -32,6 +32,7 @@ const { resolveRepoRoot } = require('../git');
 // Subcommand modules (each owns one or a small cluster of verbs).
 const { status } = require('./commands/status');
 const { setup } = require('./commands/setup');
+const { onboard } = require('./commands/onboard');
 const { install, fix, scan } = require('./commands/bootstrap');
 const { doctor } = require('./commands/doctor');
 const { review, prReview } = require('./commands/review');
@@ -208,6 +209,7 @@ async function main() {
     return setup(repairOnly.remaining);
   }
 
+  if (command === 'onboard' || command === 'welcome') return onboard(rest);
   if (command === 'prompt') return prompt(rest);
   if (command === 'pr-review') return prReview(rest);
   if (command === 'pr') return prCommand(rest);

--- a/src/context.js
+++ b/src/context.js
@@ -351,6 +351,7 @@ const COMMAND_TYPO_ALIASES = new Map([
 const SUGGESTIBLE_COMMANDS = [
   'status',
   'setup',
+  'onboard',
   'doctor',
   'branch',
   'pivot',
@@ -394,6 +395,7 @@ const CLI_COMMAND_GROUPS = [
     label: 'Setup & health',
     description: 'Install, repair, and check a repo. Run these first on a new clone.',
     commands: [
+      ['onboard', 'Guided first-run tour: where you are + the exact next command (alias: welcome)'],
       ['setup', 'Install, repair, and verify guardrails (flags: --repair, --install-only, --target, --current)'],
       ['doctor', 'Repair drift + verify (flags: --target, --current; auto-sandboxes on protected main)'],
       ['status', 'Show GitGuardex CLI + service health without modifying files'],

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -1,0 +1,98 @@
+const {
+  test,
+  assert,
+  fs,
+  path,
+  runNode,
+  initRepo,
+  defineSpawnSuite,
+} = require('./helpers/install-test-helpers');
+
+const MARKER_RELATIVE = path.join('.omx', 'state', 'onboarded.json');
+
+defineSpawnSuite('onboard integration suite', () => {
+
+  test('onboard prints the welcome tour, model, and first-task steps', () => {
+    const repoDir = initRepo();
+    const result = runNode(['onboard'], repoDir);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Welcome to GitGuardex v\d+\.\d+/);
+    assert.match(result.stdout, /WHERE YOU ARE/);
+    assert.match(result.stdout, /HOW IT WORKS/);
+    assert.match(result.stdout, /Isolated lane/);
+    assert.match(result.stdout, /File locks/);
+    assert.match(result.stdout, /Protected base/);
+    assert.match(result.stdout, /YOUR FIRST TASK/);
+    assert.match(result.stdout, /gx branch start "<task>" "<agent>"/);
+    assert.match(result.stdout, /gx branch finish --via-pr --wait-for-merge --cleanup/);
+    assert.match(result.stdout, /NEXT/);
+    assert.match(result.stdout, /gx prompt/);
+  });
+
+  test('onboard reports guardrails not yet installed on a fresh repo', () => {
+    const repoDir = initRepo();
+    const result = runNode(['onboard'], repoDir);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /guardrails/);
+    assert.match(result.stdout, /not yet/);
+    assert.match(result.stdout, /gx setup/);
+  });
+
+  test('onboard detects installed guardrails via the managed AGENTS.md block', () => {
+    const repoDir = initRepo();
+    fs.writeFileSync(
+      path.join(repoDir, 'AGENTS.md'),
+      '# AGENTS\n<!-- multiagent-safety:START -->\nmanaged\n<!-- multiagent-safety:END -->\n',
+      'utf8',
+    );
+    const result = runNode(['onboard'], repoDir);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /guardrails.*installed/);
+    assert.match(result.stdout, /done ✓/);
+  });
+
+  test('onboard writes a first-run marker under the repo state dir', () => {
+    const repoDir = initRepo();
+    const result = runNode(['onboard'], repoDir);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const markerPath = path.join(repoDir, MARKER_RELATIVE);
+    assert.ok(fs.existsSync(markerPath), 'expected onboard to write the first-run marker');
+    const parsed = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+    assert.match(parsed.version, /\d+\.\d+/);
+  });
+
+  test('onboard --reset clears the first-run marker', () => {
+    const repoDir = initRepo();
+    runNode(['onboard'], repoDir);
+    const markerPath = path.join(repoDir, MARKER_RELATIVE);
+    assert.ok(fs.existsSync(markerPath));
+
+    const result = runNode(['onboard', '--reset'], repoDir);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /cleared/);
+    assert.ok(!fs.existsSync(markerPath), 'expected --reset to remove the marker');
+  });
+
+  test('welcome alias runs the same tour', () => {
+    const repoDir = initRepo();
+    const result = runNode(['welcome'], repoDir);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Welcome to GitGuardex/);
+  });
+
+  test('onboard --help prints usage without running the tour', () => {
+    const repoDir = initRepo();
+    const result = runNode(['onboard', '--help'], repoDir);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /gx onboard — guided first-run tour/);
+    assert.doesNotMatch(result.stdout, /WHERE YOU ARE/);
+  });
+
+  test('onboard rejects unknown options', () => {
+    const repoDir = initRepo();
+    const result = runNode(['onboard', '--bogus'], repoDir);
+    assert.equal(result.status, 1, 'unknown option should exit non-zero');
+    assert.match(result.stderr, /Unknown option: --bogus/);
+  });
+
+});


### PR DESCRIPTION
## Summary

Improves the **first-run onboarding** of gitguardex with a new guided `gx onboard` command (alias `gx welcome`). Newcomers run `npm i -g @imdeadpool/guardex` → `gx setup`, but until now there was no single command that says *"here's where you are and the exact next thing to type."* This adds it.

## What `gx onboard` shows

- **WHERE YOU ARE** — repo, branch, whether guardrails are installed (detected via the managed `AGENTS.md`/`CLAUDE.md` block), origin presence, fresh-repo warning.
- **COMPANIONS** — live status of each companion + required tools, correctly distinguishing `gh`/`rtk` (required) from optional companions.
- **HOW IT WORKS** — the load-bearing model in 3 lines: isolated lanes / file locks / protected base.
- **YOUR FIRST TASK** — the exact 5-step command sequence (`setup` marked done ✓ when already wired).
- **NEXT** — pointers to `gx setup` / `prompt` / `status` / `help`.

## Behavior

- Writes a per-repo first-run marker under `.omx/state/onboarded.json` (gitignored).
- `gx setup` nudges toward the tour **exactly once** (gated by the marker).
- `--target <path>` inspects another repo; `--reset` clears the marker; `--help` prints usage.
- Registered in the help catalog and typo-suggestion list (`onbord` → "Did you mean 'onboard'?").

## Files

- `src/cli/commands/onboard.js` (new) · `src/cli/main.js` (dispatch + alias) · `src/cli/commands/setup.js` (one-time nudge) · `src/context.js` (catalog + suggestions) · `README.md` (install block + Core table) · `test/onboard.test.js` (new, 8 cases)

## Verification

- `node --test test/onboard.test.js` → **8/8 pass**
- `node --test test/cli-args-dispatch.test.js` → **11/11 pass**
- `node --test test/metadata.test.js test/release.test.js` → **37/37 pass** (README/CLI parity)
- `biome lint` on all changed files → clean

> Note: 6 pre-existing failures in `setup.test.js`/`status.test.js` (the in-flight `colony` → `colonyq` package rename + env-dependent companion-install tests) reproduce identically with this change stashed — they are not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Qyz9J4TivR9kJeAeETSUw

---
_Generated by [Claude Code](https://claude.ai/code/session_015Qyz9J4TivR9kJeAeETSUw)_