### PR TITLE
docs(preflight): note the gh-wrapper body requirement for the fail-closed marker read

### DIFF
--- a/.github/workflows/e2e-finish.yml
+++ b/.github/workflows/e2e-finish.yml
@@ -62,3 +62,6 @@ jobs:
 
       - name: Run e2e finish-via-pr smoke test
         run: bash test/e2e/finish-via-pr.sh
+
+      - name: Run e2e finish merge-hold smoke test (--no-auto-promote)
+        run: bash test/e2e/finish-merge-hold.sh

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -66,20 +66,48 @@ Disable per-call with `--no-auto-promote`, or globally with
 it, `gx branch finish`:
 
 - opens the PR as a **draft** (falls back to a ready PR on plans that
-  don't support drafts — the hold below still applies),
+  don't support drafts — the hold still applies),
+- disarms anything already primed to land the PR: previously-enabled
+  GitHub auto-merge is disabled and a ready PR is demoted back to draft,
+- **persists the hold** as a `guardex:merge-hold` marker in the PR body,
 - **skips the merge entirely** — no immediate `gh pr merge`, no
   auto-merge enable, no merge-wait polling,
 - forces the PR path: it refuses `--direct-only` and upgrades
   `--mode auto` to `--mode pr`, so nothing lands by direct push either,
-- exits 0 with the worktree retained.
+- exits 0 with the worktree retained, and prints a machine-readable
+  `MERGE_HELD=1` trailer so automation can tell "held" from "merged".
+
+The persisted marker is what makes the hold real: **every** finish
+re-run through the PR flow — the Claude stop hook, the doctor
+auto-finish sweep, `gx finish --all`, another agent following the
+finish contract — sees the marker and refuses to promote or merge.
+Without persistence, any unflagged re-run would promote the draft and
+land it, recreating the incident the hold exists to prevent.
 
 Use it when a gate outside CI (an e2e run, a manual review) must pass
-before the merge. When the gate passes, lift the hold:
+before the merge. When the gate passes, lift the hold with an
+**explicit** `--auto-promote`:
 
 ```bash
-gh pr ready <pr-url>                       # if the PR is still draft
-gx branch finish --branch <agent-branch>   # merges + cleans up
+gx branch finish --branch <agent-branch> --auto-promote
+# removes the marker, promotes the draft, merges, cleans up
 ```
+
+Only the explicit flag lifts it — `GUARDEX_FINISH_AUTO_PROMOTE=1` or
+the default does not. (Deleting the marker from the PR body by hand
+also lifts it.)
+
+Caveats:
+
+- `--gate-review` marks the PR ready before the shell script runs; the
+  hold re-demotes it to draft, but the two flags are an odd pairing —
+  prefer running the gate when you lift the hold instead.
+- The marker only guards the PR flow. A direct push to an unprotected
+  base (`--mode direct` from a separate invocation without the hold
+  env/flag) bypasses PRs entirely, as it always has.
+- `GUARDEX_FINISH_AUTO_PROMOTE=0` as an ambient env var now means
+  "every finish in this environment holds its merge" — set it per-call
+  unless a fleet-wide merge moratorium is what you want.
 
 Without the hold, the default finish flow merges the PR the moment the
 base branch has no blocking checks — there is no window to stop it.

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -51,8 +51,8 @@ its working directory. It MUST return non-zero to block a push.
 ## Auto-promote on pass
 
 After pre-flight passes, `gx branch finish` creates the PR. If the PR
-is in draft state (manually opened earlier, or via a future `--draft`
-option here), the finish script automatically marks it
+is in draft state (manually opened earlier, or opened by the merge
+hold below), the finish script automatically marks it
 ready-for-review by calling `gh pr ready`. With the budget-friendly
 CI defaults (draft PRs skip CI), this is the moment CI is allowed to
 fire — once, on a known-passing commit.
@@ -60,13 +60,37 @@ fire — once, on a known-passing commit.
 Disable per-call with `--no-auto-promote`, or globally with
 `GUARDEX_FINISH_AUTO_PROMOTE=0`.
 
+## Merge hold (`--no-auto-promote`)
+
+`--no-auto-promote` is a **merge hold**, not just a promote skip. With
+it, `gx branch finish`:
+
+- opens the PR as a **draft** (falls back to a ready PR on plans that
+  don't support drafts — the hold below still applies),
+- **skips the merge entirely** — no immediate `gh pr merge`, no
+  auto-merge enable, no merge-wait polling,
+- forces the PR path: it refuses `--direct-only` and upgrades
+  `--mode auto` to `--mode pr`, so nothing lands by direct push either,
+- exits 0 with the worktree retained.
+
+Use it when a gate outside CI (an e2e run, a manual review) must pass
+before the merge. When the gate passes, lift the hold:
+
+```bash
+gh pr ready <pr-url>                       # if the PR is still draft
+gx branch finish --branch <agent-branch>   # merges + cleans up
+```
+
+Without the hold, the default finish flow merges the PR the moment the
+base branch has no blocking checks — there is no window to stop it.
+
 ## Flags + env vars
 
 | CLI flag | Env var | Default | Effect |
 | --- | --- | --- | --- |
 | `--preflight` / `--no-preflight` | `GUARDEX_FINISH_PREFLIGHT` | `true` | Run/skip the pre-flight gate. |
 | `--preflight-script <path>` | `GUARDEX_FINISH_PREFLIGHT_SCRIPT` | `scripts/agent-preflight.sh` | Override the script path (relative to worktree, or absolute). |
-| `--auto-promote` / `--no-auto-promote` | `GUARDEX_FINISH_AUTO_PROMOTE` | `true` | Promote a draft PR to ready-for-review after pre-flight passes. |
+| `--auto-promote` / `--no-auto-promote` | `GUARDEX_FINISH_AUTO_PROMOTE` | `true` | On: promote a draft PR to ready-for-review after pre-flight passes. Off: merge hold — open the PR as draft and leave it unmerged (see above). |
 
 ## When to bypass
 

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -102,9 +102,10 @@ Caveats:
 - `--gate-review` marks the PR ready before the shell script runs; the
   hold re-demotes it to draft, but the two flags are an odd pairing —
   prefer running the gate when you lift the hold instead.
-- The marker only guards the PR flow. A direct push to an unprotected
-  base (`--mode direct` from a separate invocation without the hold
-  env/flag) bypasses PRs entirely, as it always has.
+- The finish flow consults the marker on its direct-push path too
+  (`--mode auto` diverts to the PR flow, `--direct-only` refuses), but a
+  raw `git push` outside `gx branch finish` to an unprotected base still
+  bypasses PRs entirely — base branch protection remains the backstop.
 - `GUARDEX_FINISH_AUTO_PROMOTE=0` as an ambient env var now means
   "every finish in this environment holds its merge" — set it per-call
   unless a fleet-wide merge moratorium is what you want.

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -109,6 +109,10 @@ Caveats:
 - `GUARDEX_FINISH_AUTO_PROMOTE=0` as an ambient env var now means
   "every finish in this environment holds its merge" — set it per-call
   unless a fleet-wide merge moratorium is what you want.
+- Custom `GUARDEX_GH_BIN` wrappers must answer `gh pr view --json body`
+  (real `gh` always does): the marker check fails **closed**, so a
+  wrapper that errors on it turns every PR-flow finish into a held,
+  unmerged exit.
 
 Without the hold, the default finish flow merges the PR the moment the
 base branch has no blocking checks — there is no window to stop it.

--- a/openspec/changes/agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53/.openspec.yaml
+++ b/openspec/changes/agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53/proposal.md
+++ b/openspec/changes/agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+- `gx branch finish --via-pr` opened the PR ready (never draft) and ran an
+  unconditional immediate `gh pr merge` right after `gh pr create`. On a repo
+  with no blocking checks the PR landed instantly.
+- `--no-auto-promote` only skipped promoting a pre-existing draft; it did not
+  hold the merge. A user who wanted to run an e2e gate before the merge had no
+  working way to stop the auto-merge (observed in production: a PR merged
+  before its e2e run; the flag the user reached for was inert).
+- `docs/preflight.md` already described a draft-first flow the implementation
+  never had.
+
+## What Changes
+
+- `--no-auto-promote` becomes a **merge hold** in `agent-branch-finish.sh`:
+  - the PR is created with `--draft` (ready fallback when the plan does not
+    support drafts; the hold still applies),
+  - `run_pr_flow` early-returns before the immediate `gh pr merge`, the
+    auto-merge enable, and the merge-wait polling,
+  - the hold forces the PR path: `--direct-only` is refused, `--mode auto` is
+    upgraded to `pr`,
+  - the held finish exits 0 with branch, remote branch, and worktree retained,
+    and prints how to lift the hold (`gh pr ready` + rerun finish).
+- Default behavior (auto-promote on) is unchanged: create ready PR → merge →
+  cleanup.
+- `docs/preflight.md` documents the merge hold; static invariants added to
+  `test/finish-preflight-flag.test.js`; new e2e `test/e2e/finish-merge-hold.sh`
+  wired into `.github/workflows/e2e-finish.yml`.
+
+## Impact
+
+- Surfaces: `templates/scripts/agent-branch-finish.sh` (PR flow),
+  `docs/preflight.md`, `test/finish-preflight-flag.test.js`,
+  `test/e2e/finish-merge-hold.sh`, `.github/workflows/e2e-finish.yml`.
+- Risk: low for default flows (no change when auto-promote is on, proven by
+  the existing `finish-via-pr.sh` e2e). Behavior change only for callers who
+  passed `--no-auto-promote` and relied on the merge landing anyway — that
+  reliance was the bug.
+- Rollout: none; target repos pick the script up via normal template
+  distribution.

--- a/openspec/changes/agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53/proposal.md
+++ b/openspec/changes/agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53/proposal.md
@@ -20,7 +20,14 @@
   - the hold forces the PR path: `--direct-only` is refused, `--mode auto` is
     upgraded to `pr`,
   - the held finish exits 0 with branch, remote branch, and worktree retained,
-    and prints how to lift the hold (`gh pr ready` + rerun finish).
+    prints how to lift the hold, and emits a machine-readable `MERGE_HELD=1`
+    trailer.
+- The hold is **persisted** as a `guardex:merge-hold` marker in the PR body
+  (review finding): every finish PR-flow run honors it before promoting or
+  merging, so unflagged re-runs (Claude stop hook, doctor sweep,
+  `gx finish --all`) cannot lift it. Only an explicit `--auto-promote`
+  removes the marker and proceeds to merge. Placing the hold also disarms
+  primed merge paths (GitHub auto-merge disabled, ready PR demoted to draft).
 - Default behavior (auto-promote on) is unchanged: create ready PR → merge →
   cleanup.
 - `docs/preflight.md` documents the merge hold; static invariants added to

--- a/openspec/changes/agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53/specs/no-auto-promote-merge-hold/spec.md
+++ b/openspec/changes/agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53/specs/no-auto-promote-merge-hold/spec.md
@@ -8,7 +8,11 @@
 - **THEN** the PR is created with `--draft`
 - **AND** no `gh pr merge` invocation (immediate, `--auto`, or merge-wait polling) occurs
 - **AND** the command exits 0 with the agent branch, remote branch, and worktree retained
-- **AND** the output names the hold and how to lift it (`gh pr ready`, then rerun `gx branch finish`)
+- **AND** the output includes a machine-readable `MERGE_HELD=1` trailer and how to lift the hold
+
+#### Scenario: placing the hold disarms primed merge paths
+- **WHEN** the hold is placed on a PR that is already ready or has GitHub auto-merge enabled
+- **THEN** auto-merge is disabled (`gh pr merge --disable-auto`) and the PR is demoted to draft (`gh pr ready --undo`), best-effort
 
 #### Scenario: draft unsupported falls back to ready PR, hold still applies
 - **WHEN** the host rejects draft PR creation (e.g. private repo on a plan without drafts)
@@ -21,6 +25,22 @@
 - **WHEN** `--no-auto-promote` is combined with `--direct-only`
 - **THEN** the finish exits non-zero with an error naming the conflict
 
+### Requirement: the merge hold persists across finish re-runs
+The hold SHALL be persisted as a `guardex:merge-hold` marker in the PR body, and every finish PR-flow run SHALL honor the marker before promoting or merging. Only an explicit `--auto-promote` flag lifts it.
+
+#### Scenario: unflagged re-run does not lift the hold
+- **WHEN** a held lane is finished again WITHOUT `--no-auto-promote` (e.g. by the Claude stop hook, the doctor auto-finish sweep, or `gx finish --all`)
+- **THEN** the run reports the existing hold, does not promote the draft, does not merge, and exits 0 with state retained
+
+#### Scenario: explicit --auto-promote lifts the hold
+- **WHEN** `gx branch finish --auto-promote` runs on a held lane
+- **THEN** the marker is removed, the draft is promoted, and the merge + cleanup proceed
+- **AND** `GUARDEX_FINISH_AUTO_PROMOTE=1` or the default value SHALL NOT lift the marker
+
+#### Scenario: marker removal failure keeps the hold
+- **WHEN** removing the marker fails
+- **THEN** the run continues to treat the PR as held and does not merge
+
 #### Scenario: default flow unchanged
-- **WHEN** `gx branch finish --via-pr` runs without `--no-auto-promote`
+- **WHEN** `gx branch finish --via-pr` runs without `--no-auto-promote` on a lane with no hold marker
 - **THEN** the PR is created ready, merged, and cleaned up as before

--- a/openspec/changes/agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53/specs/no-auto-promote-merge-hold/spec.md
+++ b/openspec/changes/agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53/specs/no-auto-promote-merge-hold/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: --no-auto-promote holds the merge in the finish PR flow
+`gx branch finish` with `--no-auto-promote` (or `GUARDEX_FINISH_AUTO_PROMOTE=0`) SHALL treat the flag as a merge hold: the PR is opened but never merged by the finish run.
+
+#### Scenario: PR opened as draft, merge never attempted
+- **WHEN** `gx branch finish --via-pr --no-auto-promote` runs against a repo whose host supports draft PRs
+- **THEN** the PR is created with `--draft`
+- **AND** no `gh pr merge` invocation (immediate, `--auto`, or merge-wait polling) occurs
+- **AND** the command exits 0 with the agent branch, remote branch, and worktree retained
+- **AND** the output names the hold and how to lift it (`gh pr ready`, then rerun `gx branch finish`)
+
+#### Scenario: draft unsupported falls back to ready PR, hold still applies
+- **WHEN** the host rejects draft PR creation (e.g. private repo on a plan without drafts)
+- **THEN** the finish retries `gh pr create` without `--draft`
+- **AND** the merge is still not attempted
+
+#### Scenario: hold forces the PR path
+- **WHEN** `--no-auto-promote` is combined with `--mode auto`
+- **THEN** the finish uses the PR flow (no direct push to the base branch)
+- **WHEN** `--no-auto-promote` is combined with `--direct-only`
+- **THEN** the finish exits non-zero with an error naming the conflict
+
+#### Scenario: default flow unchanged
+- **WHEN** `gx branch finish --via-pr` runs without `--no-auto-promote`
+- **THEN** the PR is created ready, merged, and cleaned up as before

--- a/openspec/changes/agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53/tasks.md
+++ b/openspec/changes/agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53/tasks.md
@@ -1,0 +1,34 @@
+## Definition of Done
+
+This change is complete only when **all** of the following are true:
+
+- Every checkbox below is checked.
+- The agent branch reaches `MERGED` state on `origin` and the PR URL + state are recorded in the completion handoff.
+- If any step blocks (test failure, conflict, ambiguous result), append a `BLOCKED:` line under section 4 explaining the blocker and **STOP**. Do not tick remaining cleanup boxes; do not silently skip the cleanup pipeline.
+
+## Handoff
+
+- Handoff: change=`agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53`; branch=`agent/claude/no-auto-promote-merge-hold-2026-07-15-20-53`; scope=`--no-auto-promote merge hold in agent-branch-finish.sh PR flow`; action=`continue this sandbox or finish cleanup after a usage-limit/manual takeover`.
+- Copy prompt: Continue `agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53` on branch `agent/claude/no-auto-promote-merge-hold-2026-07-15-20-53`. Work inside the existing sandbox, review `openspec/changes/agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53/tasks.md`, continue from the current state instead of creating a new sandbox, and when the work is done run `gx branch finish --branch agent/claude/no-auto-promote-merge-hold-2026-07-15-20-53 --base main --via-pr --wait-for-merge --cleanup`.
+
+## 1. Specification
+
+- [x] 1.1 Finalize proposal scope and acceptance criteria for `agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53`.
+- [x] 1.2 Define normative requirements in `specs/no-auto-promote-merge-hold/spec.md`.
+
+## 2. Implementation
+
+- [x] 2.1 Implement scoped behavior changes.
+- [x] 2.2 Add/update focused regression coverage.
+
+## 3. Verification
+
+- [x] 3.1 Run targeted project verification commands.
+- [x] 3.2 Run `openspec validate agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53 --type change --strict`.
+- [x] 3.3 Run `openspec validate --specs`.
+
+## 4. Cleanup (mandatory; run before claiming completion)
+
+- [ ] 4.1 Run the cleanup pipeline: `gx branch finish --branch agent/claude/no-auto-promote-merge-hold-2026-07-15-20-53 --base main --via-pr --wait-for-merge --cleanup`. This handles commit -> push -> PR create -> merge wait -> worktree prune in one invocation.
+- [ ] 4.2 Record the PR URL and final merge state (`MERGED`) in the completion handoff.
+- [ ] 4.3 Confirm the sandbox worktree is gone (`git worktree list` no longer shows the agent path; `git branch -a` shows no surviving local/remote refs for the branch).

--- a/openspec/changes/agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53/tasks.md
+++ b/openspec/changes/agent-claude-no-auto-promote-merge-hold-2026-07-15-20-53/tasks.md
@@ -29,6 +29,6 @@ This change is complete only when **all** of the following are true:
 
 ## 4. Cleanup (mandatory; run before claiming completion)
 
-- [ ] 4.1 Run the cleanup pipeline: `gx branch finish --branch agent/claude/no-auto-promote-merge-hold-2026-07-15-20-53 --base main --via-pr --wait-for-merge --cleanup`. This handles commit -> push -> PR create -> merge wait -> worktree prune in one invocation.
+- [x] 4.1 Run the cleanup pipeline: `gx branch finish --branch agent/claude/no-auto-promote-merge-hold-2026-07-15-20-53 --base main --via-pr --wait-for-merge --cleanup`. This handles commit -> push -> PR create -> merge wait -> worktree prune in one invocation.
 - [ ] 4.2 Record the PR URL and final merge state (`MERGED`) in the completion handoff.
 - [ ] 4.3 Confirm the sandbox worktree is gone (`git worktree list` no longer shows the agent path; `git branch -a` shows no surviving local/remote refs for the branch).

--- a/src/doctor/index.js
+++ b/src/doctor/index.js
@@ -332,7 +332,13 @@ function doctorFinishFlowIsPending(output) {
   return (
     /\[agent-branch-finish\] PR merge not completed yet; leaving PR open\./.test(output) ||
     /\[agent-branch-finish\] PR pending review\/check policy\./.test(output) ||
-    /\[agent-branch-finish\] PR auto-merge enabled; waiting for required checks\/reviews\./.test(output)
+    /\[agent-branch-finish\] PR auto-merge enabled; waiting for required checks\/reviews\./.test(output) ||
+    // A held merge (--no-auto-promote / guardex:merge-hold marker) exits 0
+    // with the PR open and the lane deliberately retained. Anything but
+    // 'pending' here sends the sandbox cleanup after a live held PR —
+    // force-deleting its worktree, local branch, and remote branch.
+    /^MERGE_HELD=1$/m.test(output) ||
+    /\[agent-branch-finish\] Merge hold active/.test(output)
   );
 }
 
@@ -1362,6 +1368,7 @@ function runDoctorInSandbox(options, blocked, rawIntegrations = {}) {
 }
 
 module.exports = {
+  doctorFinishFlowIsPending,
   extractAgentBranchStartMetadata,
   resolveSandboxTarget,
   buildSandboxDoctorArgs,

--- a/templates/scripts/agent-branch-finish.sh
+++ b/templates/scripts/agent-branch-finish.sh
@@ -284,6 +284,19 @@ case "$MERGE_MODE" in
     ;;
 esac
 
+# --no-auto-promote is a merge hold: the PR must stay open (draft when the
+# host supports it) until someone deliberately promotes + merges it. A direct
+# push would land the commit with no PR to hold, so the hold forces the PR
+# path and refuses --direct-only outright.
+MERGE_HELD=0
+if [[ "$AUTO_PROMOTE_DRAFT" -ne 1 ]]; then
+  if [[ "$MERGE_MODE" == "direct" ]]; then
+    echo "[agent-branch-finish] --no-auto-promote holds the merge behind a PR; it cannot be combined with --direct-only." >&2
+    exit 1
+  fi
+  MERGE_MODE="pr"
+fi
+
 AUTO_RESOLVE_MODE="$(printf '%s' "$AUTO_RESOLVE_MODE_RAW" | tr '[:upper:]' '[:lower:]')"
 case "$AUTO_RESOLVE_MODE" in
   none|safe|full) ;;
@@ -1230,13 +1243,35 @@ run_pr_flow() {
   fi
   pr_body="Automated by gx branch finish (PR flow)."
 
+  pr_create_args=(
+    --base "$BASE_BRANCH"
+    --head "$SOURCE_BRANCH"
+    --title "$pr_title"
+    --body "$pr_body"
+  )
+  # Merge hold: open the PR as a draft so nothing — required checks going
+  # green, a human clicking merge, repo auto-merge — can land it before the
+  # hold is lifted.
+  if [[ "$AUTO_PROMOTE_DRAFT" -ne 1 ]]; then
+    pr_create_args+=(--draft)
+  fi
   pr_create_output=""
-  if pr_create_output="$("$GH_BIN" pr create \
-    --base "$BASE_BRANCH" \
-    --head "$SOURCE_BRANCH" \
-    --title "$pr_title" \
-    --body "$pr_body" 2>&1)"; then
+  if pr_create_output="$("$GH_BIN" pr create "${pr_create_args[@]}" 2>&1)"; then
     :
+  elif [[ "$AUTO_PROMOTE_DRAFT" -ne 1 ]] && grep -qi 'draft pull requests are not supported' <<<"$pr_create_output"; then
+    # Some plans reject drafts (e.g. private repos on GitHub Free). Fall back
+    # to a ready PR — the merge-hold early return below still applies.
+    echo "[agent-branch-finish] Draft PRs unsupported in this repository; opening a ready PR (merge still held)." >&2
+    if ! pr_create_output="$("$GH_BIN" pr create \
+      --base "$BASE_BRANCH" \
+      --head "$SOURCE_BRANCH" \
+      --title "$pr_title" \
+      --body "$pr_body" 2>&1)"; then
+      if ! grep -qiE 'already exists|a pull request for branch' <<<"$pr_create_output"; then
+        echo "[agent-branch-finish] gh pr create failed:" >&2
+        echo "${pr_create_output}" >&2
+      fi
+    fi
   else
     # Idempotent: a PR already opened for this head is fine — fall through
     # to `gh pr view` so we still capture the URL. Anything else is a real
@@ -1262,6 +1297,16 @@ run_pr_flow() {
   # Pre-flight already passed by the time we reach the PR; promote any
   # existing draft so the budget-friendly CI gate fires once.
   maybe_auto_promote_pr "$pr_url"
+
+  # Merge hold (--no-auto-promote): stop before the merge attempts below.
+  # Without this return the unconditional `gh pr merge` lands the PR the
+  # moment the repo has no blocking checks — the exact accident the flag
+  # exists to prevent.
+  if [[ "$AUTO_PROMOTE_DRAFT" -ne 1 ]]; then
+    MERGE_HELD=1
+    echo "[agent-branch-finish] Merge held (--no-auto-promote): PR left unmerged for review/e2e." >&2
+    return 2
+  fi
 
   merge_output=""
   if merge_output="$("$GH_BIN" pr merge "$SOURCE_BRANCH" --squash --delete-branch 2>&1)"; then
@@ -1325,6 +1370,10 @@ if [[ "$PUSH_ENABLED" -eq 1 ]]; then
         echo "[agent-branch-finish] PR flow created/updated branch '${SOURCE_BRANCH}' against '${BASE_BRANCH}'." >&2
         if [[ -n "$pr_url" ]]; then
           echo "[agent-branch-finish] PR: ${pr_url}" >&2
+        fi
+        if [[ "$MERGE_HELD" -eq 1 ]]; then
+          echo "[agent-branch-finish] Merge held by --no-auto-promote; worktree retained. When your gate (review/e2e) passes: 'gh pr ready ${pr_url:-<pr-url>}' then rerun 'gx branch finish --branch ${SOURCE_BRANCH}' to merge + cleanup." >&2
+          exit 0
         fi
         if [[ "$WAIT_FOR_MERGE" -eq 1 ]]; then
           echo "[agent-branch-finish] Merge did not complete within wait window; keeping branch open." >&2

--- a/templates/scripts/agent-branch-finish.sh
+++ b/templates/scripts/agent-branch-finish.sh
@@ -127,22 +127,34 @@ run_preflight() {
 # prevent. The durable artifact is a marker in the PR body; only an explicit
 # --auto-promote finish lifts it.
 HOLD_MARKER='guardex:merge-hold'
+HOLD_MARKER_COMMENT="<!-- ${HOLD_MARKER} -->"
 
-pr_body_text() {
-  "$GH_BIN" pr view "$1" --json body --jq '.body' 2>/dev/null || true
-}
-
-pr_has_hold_marker() {
-  pr_body_text "$1" | grep -qF "$HOLD_MARKER"
+# Marker state for the PR selected by $1 (URL or branch).
+# Returns: 0 = marker present; 1 = no marker; 2 = PR body unreadable (no PR,
+# gh missing, transient failure). Callers pick the failure direction: the PR
+# flow fails CLOSED (unknown => held), the direct-push guard fails open
+# (unknown usually means "no PR at all").
+pr_hold_marker_state() {
+  local body
+  if ! body="$("$GH_BIN" pr view "$1" --json body --jq '.body' 2>/dev/null)"; then
+    return 2
+  fi
+  if grep -qF "$HOLD_MARKER_COMMENT" <<<"$body"; then
+    return 0
+  fi
+  return 1
 }
 
 place_hold_marker() {
   local pr_url="$1" body
-  body="$(pr_body_text "$pr_url")"
-  if grep -qF "$HOLD_MARKER" <<<"$body"; then
+  if ! body="$("$GH_BIN" pr view "$pr_url" --json body --jq '.body' 2>/dev/null)"; then
+    echo "[agent-branch-finish] Warning: could not read the PR body; NOT writing the ${HOLD_MARKER} marker (refusing to clobber the body). The hold will NOT survive an unflagged re-run." >&2
     return 0
   fi
-  if ! "$GH_BIN" pr edit "$pr_url" --body "${body}"$'\n\n'"<!-- ${HOLD_MARKER} -->" >/dev/null 2>&1; then
+  if grep -qF "$HOLD_MARKER_COMMENT" <<<"$body"; then
+    return 0
+  fi
+  if ! "$GH_BIN" pr edit "$pr_url" --body "${body}"$'\n\n'"${HOLD_MARKER_COMMENT}" >/dev/null 2>&1; then
     echo "[agent-branch-finish] Warning: could not write the ${HOLD_MARKER} marker to the PR body; the hold will NOT survive an unflagged re-run of the finish flow." >&2
   fi
 }
@@ -151,11 +163,14 @@ place_hold_marker() {
 # caller must keep treating the PR as held.
 remove_hold_marker() {
   local pr_url="$1" body
-  body="$(pr_body_text "$pr_url")"
-  if ! grep -qF "$HOLD_MARKER" <<<"$body"; then
+  if ! body="$("$GH_BIN" pr view "$pr_url" --json body --jq '.body' 2>/dev/null)"; then
+    echo "[agent-branch-finish] Warning: could not read the PR body to remove the ${HOLD_MARKER} marker; the hold remains in force." >&2
+    return 1
+  fi
+  if ! grep -qF "$HOLD_MARKER_COMMENT" <<<"$body"; then
     return 0
   fi
-  body="$(printf '%s\n' "$body" | grep -vF "$HOLD_MARKER")"
+  body="$(printf '%s\n' "$body" | grep -vF "$HOLD_MARKER_COMMENT")"
   if ! "$GH_BIN" pr edit "$pr_url" --body "$body" >/dev/null 2>&1; then
     echo "[agent-branch-finish] Warning: could not remove the ${HOLD_MARKER} marker; the hold remains in force." >&2
     return 1
@@ -1345,7 +1360,17 @@ run_pr_flow() {
   # Honor a persisted hold BEFORE any promotion or merge. Only an explicit
   # --auto-promote flag lifts it; the default (env-derived) auto-promote must
   # not, or every unflagged re-run would lift holds it never placed.
-  if pr_has_hold_marker "$pr_url"; then
+  hold_state=0
+  pr_hold_marker_state "$pr_url" || hold_state=$?
+  if [[ "$hold_state" -eq 2 ]]; then
+    # Fail closed: a transient failure reading the body must not silently
+    # lift a hold. A spurious hold is recoverable (rerun); a spurious lift
+    # merges the PR.
+    MERGE_HELD=1
+    echo "[agent-branch-finish] Could not read the PR body to check for a merge hold; treating the PR as held (fail closed)." >&2
+    return 2
+  fi
+  if [[ "$hold_state" -eq 0 ]]; then
     if [[ "$AUTO_PROMOTE_EXPLICIT" -eq 1 && "$AUTO_PROMOTE_DRAFT" -eq 1 ]]; then
       if ! remove_hold_marker "$pr_url"; then
         MERGE_HELD=1
@@ -1419,10 +1444,25 @@ if [[ "$PUSH_ENABLED" -eq 1 ]]; then
     exit 1
   fi
   if [[ "$MERGE_MODE" != "pr" ]]; then
-    maybe_push_changed_submodule_branches "$start_ref" "$SOURCE_BRANCH"
-    if ! direct_push_output="$(git -C "$integration_worktree" push origin "HEAD:${BASE_BRANCH}" 2>&1)"; then
-      direct_push_error="$direct_push_output"
+    # A persisted merge hold must also stop the direct-push shortcut, or a
+    # rerun in auto/direct mode would land the held work without ever
+    # consulting the marker. State 2 (no PR / body unreadable) proceeds:
+    # most direct pushes have no PR at all.
+    direct_hold_state=0
+    pr_hold_marker_state "$SOURCE_BRANCH" || direct_hold_state=$?
+    if [[ "$direct_hold_state" -eq 0 ]]; then
+      if [[ "$MERGE_MODE" == "direct" ]]; then
+        echo "[agent-branch-finish] Existing merge hold (${HOLD_MARKER}) on the PR for '${SOURCE_BRANCH}'; refusing the --direct-only push. Lift with 'gx branch finish --branch ${SOURCE_BRANCH} --auto-promote'." >&2
+        exit 1
+      fi
+      echo "[agent-branch-finish] Existing merge hold (${HOLD_MARKER}) on the PR for '${SOURCE_BRANCH}'; skipping the direct push and using the PR flow." >&2
       merge_completed=0
+    else
+      maybe_push_changed_submodule_branches "$start_ref" "$SOURCE_BRANCH"
+      if ! direct_push_output="$(git -C "$integration_worktree" push origin "HEAD:${BASE_BRANCH}" 2>&1)"; then
+        direct_push_error="$direct_push_output"
+        merge_completed=0
+      fi
     fi
   else
     merge_completed=0

--- a/templates/scripts/agent-branch-finish.sh
+++ b/templates/scripts/agent-branch-finish.sh
@@ -22,6 +22,10 @@ AUTO_RESOLVE_SAFE_GLOBS_RAW="${GUARDEX_FINISH_AUTO_RESOLVE_SAFE_GLOBS-$AUTO_RESO
 PREFLIGHT_ENABLED_RAW="${GUARDEX_FINISH_PREFLIGHT:-true}"
 PREFLIGHT_SCRIPT_RAW="${GUARDEX_FINISH_PREFLIGHT_SCRIPT:-scripts/agent-preflight.sh}"
 AUTO_PROMOTE_DRAFT_RAW="${GUARDEX_FINISH_AUTO_PROMOTE:-true}"
+# Only an explicit --auto-promote FLAG lifts a persisted merge hold; the env
+# default (or GUARDEX_FINISH_AUTO_PROMOTE=1) must not, or any unflagged
+# re-run would silently lift holds placed by earlier runs.
+AUTO_PROMOTE_EXPLICIT=0
 
 run_guardex_cli() {
   if [[ -n "$CLI_ENTRY" ]]; then
@@ -114,6 +118,48 @@ run_preflight() {
   fi
   echo "[agent-branch-finish] Pre-flight FAILED; refusing push. Override with --no-preflight if you really mean it." >&2
   return 1
+}
+
+# Persisted merge hold. The hold must bind EVERY finish run on the lane, not
+# just the one that placed it — otherwise any unflagged re-run (the Claude
+# stop hook, the doctor auto-finish sweep, `gx finish --all`) would promote
+# the draft and merge, recreating exactly the incident the hold exists to
+# prevent. The durable artifact is a marker in the PR body; only an explicit
+# --auto-promote finish lifts it.
+HOLD_MARKER='guardex:merge-hold'
+
+pr_body_text() {
+  "$GH_BIN" pr view "$1" --json body --jq '.body' 2>/dev/null || true
+}
+
+pr_has_hold_marker() {
+  pr_body_text "$1" | grep -qF "$HOLD_MARKER"
+}
+
+place_hold_marker() {
+  local pr_url="$1" body
+  body="$(pr_body_text "$pr_url")"
+  if grep -qF "$HOLD_MARKER" <<<"$body"; then
+    return 0
+  fi
+  if ! "$GH_BIN" pr edit "$pr_url" --body "${body}"$'\n\n'"<!-- ${HOLD_MARKER} -->" >/dev/null 2>&1; then
+    echo "[agent-branch-finish] Warning: could not write the ${HOLD_MARKER} marker to the PR body; the hold will NOT survive an unflagged re-run of the finish flow." >&2
+  fi
+}
+
+# Returns non-zero when the marker could not be removed, in which case the
+# caller must keep treating the PR as held.
+remove_hold_marker() {
+  local pr_url="$1" body
+  body="$(pr_body_text "$pr_url")"
+  if ! grep -qF "$HOLD_MARKER" <<<"$body"; then
+    return 0
+  fi
+  body="$(printf '%s\n' "$body" | grep -vF "$HOLD_MARKER")"
+  if ! "$GH_BIN" pr edit "$pr_url" --body "$body" >/dev/null 2>&1; then
+    echo "[agent-branch-finish] Warning: could not remove the ${HOLD_MARKER} marker; the hold remains in force." >&2
+    return 1
+  fi
 }
 
 # After a PR exists, if it is in draft and auto-promote is enabled,
@@ -250,10 +296,12 @@ while [[ $# -gt 0 ]]; do
       ;;
     --no-auto-promote)
       AUTO_PROMOTE_DRAFT_RAW="false"
+      AUTO_PROMOTE_EXPLICIT=0
       shift
       ;;
     --auto-promote)
       AUTO_PROMOTE_DRAFT_RAW="true"
+      AUTO_PROMOTE_EXPLICIT=1
       shift
       ;;
     *)
@@ -291,7 +339,7 @@ esac
 MERGE_HELD=0
 if [[ "$AUTO_PROMOTE_DRAFT" -ne 1 ]]; then
   if [[ "$MERGE_MODE" == "direct" ]]; then
-    echo "[agent-branch-finish] --no-auto-promote holds the merge behind a PR; it cannot be combined with --direct-only." >&2
+    echo "[agent-branch-finish] The merge hold (set via --no-auto-promote or GUARDEX_FINISH_AUTO_PROMOTE=0) keeps the merge behind a PR; it cannot be combined with --direct-only. Pass --auto-promote to override." >&2
     exit 1
   fi
   MERGE_MODE="pr"
@@ -1294,6 +1342,23 @@ run_pr_flow() {
   fi
   echo "[agent-branch-finish] PR URL: ${pr_url}" >&2
 
+  # Honor a persisted hold BEFORE any promotion or merge. Only an explicit
+  # --auto-promote flag lifts it; the default (env-derived) auto-promote must
+  # not, or every unflagged re-run would lift holds it never placed.
+  if pr_has_hold_marker "$pr_url"; then
+    if [[ "$AUTO_PROMOTE_EXPLICIT" -eq 1 && "$AUTO_PROMOTE_DRAFT" -eq 1 ]]; then
+      if ! remove_hold_marker "$pr_url"; then
+        MERGE_HELD=1
+        return 2
+      fi
+      echo "[agent-branch-finish] Merge hold lifted (explicit --auto-promote)." >&2
+    else
+      MERGE_HELD=1
+      echo "[agent-branch-finish] Existing merge hold (${HOLD_MARKER}) honored; not promoting or merging." >&2
+      return 2
+    fi
+  fi
+
   # Pre-flight already passed by the time we reach the PR; promote any
   # existing draft so the budget-friendly CI gate fires once.
   maybe_auto_promote_pr "$pr_url"
@@ -1304,6 +1369,13 @@ run_pr_flow() {
   # exists to prevent.
   if [[ "$AUTO_PROMOTE_DRAFT" -ne 1 ]]; then
     MERGE_HELD=1
+    # Disarm anything that could still land the PR while held: GitHub
+    # auto-merge armed by an earlier run, and ready state left by an earlier
+    # run or the gate-review markReady step. Best-effort; the marker below is
+    # the load-bearing hold.
+    "$GH_BIN" pr merge "$pr_url" --disable-auto >/dev/null 2>&1 || true
+    "$GH_BIN" pr ready --undo "$pr_url" >/dev/null 2>&1 || true
+    place_hold_marker "$pr_url"
     echo "[agent-branch-finish] Merge held (--no-auto-promote): PR left unmerged for review/e2e." >&2
     return 2
   fi
@@ -1372,7 +1444,8 @@ if [[ "$PUSH_ENABLED" -eq 1 ]]; then
           echo "[agent-branch-finish] PR: ${pr_url}" >&2
         fi
         if [[ "$MERGE_HELD" -eq 1 ]]; then
-          echo "[agent-branch-finish] Merge held by --no-auto-promote; worktree retained. When your gate (review/e2e) passes: 'gh pr ready ${pr_url:-<pr-url>}' then rerun 'gx branch finish --branch ${SOURCE_BRANCH}' to merge + cleanup." >&2
+          echo "[agent-branch-finish] Merge hold active; worktree retained. When your gate (review/e2e) passes, lift the hold with: gx branch finish --branch ${SOURCE_BRANCH} --auto-promote" >&2
+          echo "MERGE_HELD=1"
           exit 0
         fi
         if [[ "$WAIT_FOR_MERGE" -eq 1 ]]; then

--- a/templates/scripts/agent-branch-finish.sh
+++ b/templates/scripts/agent-branch-finish.sh
@@ -1354,6 +1354,10 @@ run_pr_flow() {
       echo "[agent-branch-finish] Merge hold lifted (explicit --auto-promote)." >&2
     else
       MERGE_HELD=1
+      # Re-demote in case an outer layer (gate-review markReady, a human)
+      # promoted the held PR since the hold was placed. Idempotent when the
+      # PR is already draft; best-effort like the placement disarm.
+      "$GH_BIN" pr ready --undo "$pr_url" >/dev/null 2>&1 || true
       echo "[agent-branch-finish] Existing merge hold (${HOLD_MARKER}) honored; not promoting or merging." >&2
       return 2
     fi

--- a/templates/scripts/agent-claude-stop-finish.sh
+++ b/templates/scripts/agent-claude-stop-finish.sh
@@ -165,7 +165,11 @@ echo "[agent-claude-stop-finish] ${branch}: handing off to gx ${finish_cmd[*]}" 
 finish_output=""
 if finish_output="$(run_guardex_cli "${finish_cmd[@]}" 2>&1)"; then
   printf '%s\n' "$finish_output"
-  echo "[agent-claude-stop-finish] ${branch}: finish completed." >&2
+  if grep -q '^MERGE_HELD=1$' <<<"$finish_output"; then
+    echo "[agent-claude-stop-finish] ${branch}: merge held (guardex:merge-hold); sandbox kept at ${worktree_path}. Lift with: gx branch finish --branch ${branch} --auto-promote" >&2
+  else
+    echo "[agent-claude-stop-finish] ${branch}: finish completed." >&2
+  fi
   exit 0
 fi
 

--- a/test/doctor.test.js
+++ b/test/doctor.test.js
@@ -423,6 +423,10 @@ if [[ "$1" == "pr" && "$2" == "create" ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ " $* " == *" --json body "* ]]; then
+    echo ""
+    exit 0
+  fi
   if [[ " $* " == *" --json url "* ]]; then
     echo "https://example.test/pr/doctor-autofinish"
     exit 0
@@ -519,6 +523,10 @@ if [[ "$1" == "pr" && "$2" == "create" ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ " $* " == *" --json body "* ]]; then
+    echo ""
+    exit 0
+  fi
   if [[ " $* " == *" --json url "* ]]; then
     echo "https://example.test/pr/doctor-autofinish-unmerged"
     exit 0
@@ -575,6 +583,10 @@ if [[ "$1" == "pr" && "$2" == "create" ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ " $* " == *" --json body "* ]]; then
+    echo ""
+    exit 0
+  fi
   if [[ " $* " == *" --json url "* ]]; then
     echo "https://example.test/pr/doctor-auto-finish-ready"
     exit 0
@@ -730,6 +742,10 @@ if [[ "$1" == "pr" && "$2" == "create" ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ " $* " == *" --json body "* ]]; then
+    echo ""
+    exit 0
+  fi
   if [[ " $* " == *" --json url "* ]]; then
     echo "https://example.test/pr/doctor-no-wait"
     exit 0
@@ -1144,6 +1160,10 @@ if [[ "$1" == "pr" && "$2" == "create" ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ " $* " == *" --json body "* ]]; then
+    echo ""
+    exit 0
+  fi
   if [[ " $* " == *" --json url "* ]]; then
     echo "https://example.test/pr/nested-doctor-pending"
     exit 0
@@ -1285,4 +1305,23 @@ test('gx doctor preserves stranded worktrees when GUARDEX_SKIP_AUTO_WORKTREE_PRU
   );
 });
 
+});
+
+// Pure classifier guard: a held merge (--no-auto-promote / guardex:merge-hold)
+// exits 0 with the PR open and the lane deliberately retained. It MUST classify
+// as pending — anything else sends the doctor sandbox cleanup after a live held
+// PR, force-deleting its worktree, local branch, and remote branch.
+test('doctorFinishFlowIsPending treats a held merge as pending', () => {
+  const { doctorFinishFlowIsPending } = require('../src/doctor');
+  assert.equal(doctorFinishFlowIsPending('prelude\nMERGE_HELD=1\n'), true);
+  assert.equal(
+    doctorFinishFlowIsPending('[agent-branch-finish] Merge hold active; worktree retained.'),
+    true,
+  );
+  assert.equal(
+    doctorFinishFlowIsPending("[agent-branch-finish] Merged 'agent/x' into 'main' via pr flow."),
+    false,
+  );
+  // The trailer must match as a full line, not inside prose.
+  assert.equal(doctorFinishFlowIsPending('note: set MERGE_HELD=1 to hold'), false);
 });

--- a/test/e2e/finish-merge-hold.sh
+++ b/test/e2e/finish-merge-hold.sh
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
-# e2e smoke test for the `--no-auto-promote` MERGE HOLD in
+# e2e lifecycle test for the `--no-auto-promote` MERGE HOLD in
 # `gx branch finish --via-pr`.
 #
 # Regression under test: run_pr_flow used to run an unconditional
 # `gh pr merge` right after `gh pr create`, so on a repo with no blocking
 # checks the PR landed instantly and `--no-auto-promote` changed nothing.
-# The hold must (a) open the PR as a draft, (b) never attempt a merge,
-# (c) exit 0 with the branch + worktree retained.
+# The hold must also be PERSISTED (guardex:merge-hold marker in the PR
+# body): an unflagged re-run — the Claude stop hook, the doctor sweep,
+# `gx finish --all` — must NOT lift it; only an explicit `--auto-promote`
+# finish may.
 #
-# Same harness as finish-via-pr.sh: local bare origin, bash mock for `gh`
-# injected through `GUARDEX_GH_BIN`, no network.
+# Same harness as finish-via-pr.sh: local bare origin, stateful bash mock
+# for `gh` injected through `GUARDEX_GH_BIN`, no network.
 #
-# Asserts (all required for PASS):
-#   * `gx branch finish --via-pr --cleanup --no-auto-promote` exits 0.
-#   * The gh mock received `pr create` WITH `--draft`.
-#   * The gh mock NEVER received `pr merge`.
-#   * The finish output announces the merge hold.
-#   * The agent commit did NOT land on origin's base branch.
-#   * The local agent branch, remote agent branch, and worktree all remain.
+# Stage 1  finish --no-auto-promote      → draft PR, marker placed, no merge,
+#                                          exit 0, worktree retained
+# Stage 2  finish (no flag; stop-hook    → hold honored: no promote, no merge,
+#          shape)                          marker + draft retained, exit 0
+# Stage 3  finish --auto-promote         → marker removed, PR promoted, merged,
+#                                          cleaned up
 
 set -euo pipefail
 
@@ -40,7 +41,10 @@ NODE_BIN="${NODE_BIN_RESOLVED}"
 export GUARDEX_CLI_ENTRY="${CLI_ENTRY}"
 export GUARDEX_NODE_BIN="${NODE_BIN}"
 
-run_gx() {
+# Strip agent-session env so the CLI (and the git hooks it installs) treat the
+# fixture as a fresh human checkout even when this script runs from inside a
+# Claude/Codex agent worktree.
+run_clean() {
   env \
     -u CODEX_THREAD_ID \
     -u OMX_SESSION_ID \
@@ -54,7 +58,11 @@ run_gx() {
     GUARDEX_HOME_DIR="${GUARDEX_HOME_DIR}" \
     GUARDEX_CLI_ENTRY="${CLI_ENTRY}" \
     GUARDEX_NODE_BIN="${NODE_BIN}" \
-    "${NODE_BIN}" "${CLI_ENTRY}" "$@"
+    "$@"
+}
+
+run_gx() {
+  run_clean "${NODE_BIN}" "${CLI_ENTRY}" "$@"
 }
 
 # ---- isolated scratch dir -------------------------------------------------
@@ -70,14 +78,22 @@ MOCK_BIN_DIR="${SCRATCH}/mock-bin"
 export GUARDEX_HOME_DIR="${SCRATCH}/guardex-home"
 mkdir -p "${MOCK_BIN_DIR}" "${GUARDEX_HOME_DIR}"
 
-# ---- gh mock: records calls; a `pr merge` call is the FAILURE signal ------
+# ---- stateful gh mock -----------------------------------------------------
+# Tracks PR body (for the hold marker), draft state, and merged state.
+# `pr merge` on a draft fails like real gh; a real merge squashes into the
+# bare origin so post-merge assertions are genuine.
 GH_MOCK_STATE="${SCRATCH}/gh-mock-state"
 mkdir -p "${GH_MOCK_STATE}"
 cat > "${MOCK_BIN_DIR}/gh" <<'GH_MOCK'
 #!/usr/bin/env bash
 set -euo pipefail
 state_dir="${GUARDEX_E2E_GH_STATE:?GUARDEX_E2E_GH_STATE not set}"
+origin_dir="${GUARDEX_E2E_ORIGIN_DIR:?GUARDEX_E2E_ORIGIN_DIR not set}"
+base_branch="${GUARDEX_E2E_BASE_BRANCH:?GUARDEX_E2E_BASE_BRANCH not set}"
 pr_url_file="${state_dir}/pr-url"
+pr_body_file="${state_dir}/pr-body"
+pr_draft_file="${state_dir}/pr-draft"
+merge_marker="${state_dir}/merged"
 log_file="${state_dir}/gh-calls.log"
 echo "gh $*" >>"${log_file}"
 
@@ -88,12 +104,73 @@ emit_url() {
   cat "${pr_url_file}"
 }
 
+read_body() {
+  cat "${pr_body_file}" 2>/dev/null || printf ''
+}
+
+read_draft() {
+  cat "${pr_draft_file}" 2>/dev/null || printf 'false'
+}
+
+perform_merge_in_origin() {
+  local head_branch="$1"
+  if [[ -f "${merge_marker}" ]]; then
+    return 0
+  fi
+  local merge_workdir
+  merge_workdir="$(mktemp -d -t guardex-e2e-merge-XXXXXX)"
+  git clone --quiet "${origin_dir}" "${merge_workdir}/repo" >/dev/null 2>&1
+  git -C "${merge_workdir}/repo" config user.email "e2e-bot@example.invalid"
+  git -C "${merge_workdir}/repo" config user.name "guardex-e2e"
+  git -C "${merge_workdir}/repo" fetch --quiet origin "${head_branch}:${head_branch}"
+  git -C "${merge_workdir}/repo" checkout --quiet "${base_branch}"
+  git -C "${merge_workdir}/repo" merge --quiet --squash "${head_branch}" >/dev/null
+  git -C "${merge_workdir}/repo" commit --quiet -m "Merge ${head_branch} into ${base_branch} (e2e mock)"
+  git -C "${merge_workdir}/repo" push --quiet origin "${base_branch}"
+  git -C "${merge_workdir}/repo" push --quiet origin --delete "${head_branch}" || true
+  rm -rf "${merge_workdir}"
+  : >"${merge_marker}"
+}
+
 case "${1:-}" in
   pr)
     shift
     case "${1:-}" in
       create)
+        # Record draft-ness and initial body from the create args.
+        shift
+        is_draft="false"
+        body=""
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            --draft) is_draft="true"; shift ;;
+            --body) body="${2:-}"; shift 2 ;;
+            *) shift ;;
+          esac
+        done
+        if [[ ! -f "${pr_url_file}" ]]; then
+          echo "${is_draft}" >"${pr_draft_file}"
+          printf '%s' "${body}" >"${pr_body_file}"
+        fi
         emit_url >/dev/null
+        exit 0
+        ;;
+      edit)
+        shift
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            --body) printf '%s' "${2:-}" >"${pr_body_file}"; shift 2 ;;
+            *) shift ;;
+          esac
+        done
+        exit 0
+        ;;
+      ready)
+        if [[ "${2:-}" == "--undo" || "${3:-}" == "--undo" ]]; then
+          echo "true" >"${pr_draft_file}"
+        else
+          echo "false" >"${pr_draft_file}"
+        fi
         exit 0
         ;;
       view)
@@ -108,11 +185,19 @@ case "${1:-}" in
           url)
             emit_url
             ;;
+          body)
+            read_body
+            echo
+            ;;
           isDraft)
-            echo "true"
+            read_draft
             ;;
           state,mergedAt,url)
-            printf 'OPEN\x1f\x1f%s\n' "$(emit_url)"
+            if [[ -f "${merge_marker}" ]]; then
+              printf 'MERGED\x1f2026-01-01T00:00:00Z\x1f%s\n' "$(emit_url)"
+            else
+              printf 'OPEN\x1f\x1f%s\n' "$(emit_url)"
+            fi
             ;;
           *)
             echo "mock-gh: unsupported pr view --json '${json_fields}'" >&2
@@ -122,16 +207,26 @@ case "${1:-}" in
         exit 0
         ;;
       merge)
-        # The hold must prevent this call entirely. Log already captured it;
-        # fail loudly so a regression cannot silently "merge".
-        echo "mock-gh: pr merge called despite --no-auto-promote hold" >&2
-        exit 2
+        head_branch="${2:-}"
+        for arg in "$@"; do
+          if [[ "${arg}" == "--disable-auto" ]]; then
+            # Disarming auto-merge is a hold-side no-op here.
+            exit 0
+          fi
+        done
+        if [[ "$(read_draft)" == "true" ]]; then
+          echo "mock-gh: Pull request is still a draft and cannot be merged" >&2
+          exit 1
+        fi
+        if [[ -z "${head_branch}" ]]; then
+          echo "mock-gh: pr merge missing branch" >&2
+          exit 2
+        fi
+        perform_merge_in_origin "${head_branch}"
+        exit 0
         ;;
       list)
         printf ''
-        exit 0
-        ;;
-      ready)
         exit 0
         ;;
       *)
@@ -163,17 +258,17 @@ JSON
 git -C "${FIXTURE_REPO}" add package.json
 git -C "${FIXTURE_REPO}" commit --quiet -m "seed"
 
-git init --quiet --bare "${ORIGIN_DIR}"
+git init --quiet --bare --initial-branch=main "${ORIGIN_DIR}"
 git -C "${FIXTURE_REPO}" remote add origin "${ORIGIN_DIR}"
-git -C "${FIXTURE_REPO}" push --quiet -u origin main
+run_clean git -C "${FIXTURE_REPO}" push --quiet -u origin main
 
 # ---- run `gx setup` ------------------------------------------------------
 echo "==> gx setup"
 run_gx setup --target "${FIXTURE_REPO}" --no-global-install
 
 git -C "${FIXTURE_REPO}" add -A
-ALLOW_COMMIT_ON_PROTECTED_BRANCH=1 git -C "${FIXTURE_REPO}" commit --quiet -m "apply gx setup"
-ALLOW_PUSH_ON_PROTECTED_BRANCH=1 git -C "${FIXTURE_REPO}" push --quiet origin main
+run_clean env ALLOW_COMMIT_ON_PROTECTED_BRANCH=1 git -C "${FIXTURE_REPO}" commit --quiet -m "apply gx setup"
+run_clean env ALLOW_PUSH_ON_PROTECTED_BRANCH=1 git -C "${FIXTURE_REPO}" push --quiet origin main
 
 # ---- run `gx branch start` ----------------------------------------------
 echo "==> gx branch start"
@@ -207,97 +302,140 @@ echo "guardex e2e: this file must NOT land on base while the merge is held." \
 git -C "${AGENT_WORKTREE}" add "${TRIVIAL_FILE}"
 git -C "${AGENT_WORKTREE}" commit --quiet -m "e2e: change held behind --no-auto-promote"
 
-# ---- run `gx branch finish --via-pr --cleanup --no-auto-promote` ----------
-echo "==> gx branch finish --via-pr --cleanup --no-auto-promote"
-FINISH_OUT="${SCRATCH}/branch-finish.out"
-set +e
-(
-  cd "${FIXTURE_REPO}"
-  env \
-    -u CODEX_THREAD_ID \
-    -u OMX_SESSION_ID \
-    -u CODEX_CI \
-    -u CLAUDECODE \
-    -u CLAUDE_CODE_SESSION_ID \
-    -u GUARDEX_AGENT_BRANCH \
-    -u GUARDEX_AGENT_WORKTREE \
-    -u GIT_DIR \
-    -u GIT_WORK_TREE \
-    PATH="${MOCK_BIN_DIR}:${PATH}" \
-    GUARDEX_GH_BIN="${MOCK_BIN_DIR}/gh" \
-    GUARDEX_E2E_GH_STATE="${GH_MOCK_STATE}" \
-    GUARDEX_HOME_DIR="${GUARDEX_HOME_DIR}" \
-    GUARDEX_CLI_ENTRY="${CLI_ENTRY}" \
-    GUARDEX_NODE_BIN="${NODE_BIN}" \
-    "${NODE_BIN}" "${CLI_ENTRY}" branch finish \
-    --branch "${AGENT_BRANCH}" \
-    --base main \
-    --via-pr \
-    --cleanup \
-    --no-auto-promote
-) >"${FINISH_OUT}" 2>&1
-FINISH_STATUS=$?
-set -e
-cat "${FINISH_OUT}"
+# ---- shared finish runner -------------------------------------------------
+run_finish() {
+  local out_file="$1"
+  shift
+  set +e
+  (
+    cd "${FIXTURE_REPO}"
+    run_clean env \
+      PATH="${MOCK_BIN_DIR}:${PATH}" \
+      GUARDEX_GH_BIN="${MOCK_BIN_DIR}/gh" \
+      GUARDEX_E2E_GH_STATE="${GH_MOCK_STATE}" \
+      GUARDEX_E2E_ORIGIN_DIR="${ORIGIN_DIR}" \
+      GUARDEX_E2E_BASE_BRANCH="main" \
+      "${NODE_BIN}" "${CLI_ENTRY}" branch finish \
+      --branch "${AGENT_BRANCH}" \
+      --base main \
+      --via-pr \
+      --wait-for-merge \
+      --wait-timeout-seconds 30 \
+      --wait-poll-seconds 0 \
+      --cleanup \
+      "$@"
+  ) >"${out_file}" 2>&1
+  local status=$?
+  set -e
+  return "${status}"
+}
 
-# ---- assertions ----------------------------------------------------------
-echo "==> assertions"
+assert_no_real_merge() {
+  if grep '^gh pr merge' "${GH_MOCK_STATE}/gh-calls.log" | grep -qv -- '--disable-auto'; then
+    echo "FAIL: a real 'gh pr merge' was attempted while the merge is held" >&2
+    cat "${GH_MOCK_STATE}/gh-calls.log" >&2 || true
+    exit 1
+  fi
+}
 
-# 1) Held finish exits 0 (intentional hold, not a failure).
-if [[ "${FINISH_STATUS}" -ne 0 ]]; then
-  echo "FAIL: gx branch finish exited with status ${FINISH_STATUS} (held merge must exit 0)" >&2
-  echo "---- gh mock call log ----" >&2
-  cat "${GH_MOCK_STATE}/gh-calls.log" >&2 || true
+assert_not_on_base() {
+  if git -C "${ORIGIN_DIR}" ls-tree -r main --name-only | grep -qx "${TRIVIAL_FILE}"; then
+    echo "FAIL: agent file '${TRIVIAL_FILE}' landed on origin/main despite the hold" >&2
+    exit 1
+  fi
+}
+
+# ---- stage 1: place the hold ----------------------------------------------
+echo "==> stage 1: gx branch finish --no-auto-promote (place hold)"
+FINISH_OUT_1="${SCRATCH}/finish-1.out"
+if ! run_finish "${FINISH_OUT_1}" --no-auto-promote; then
+  cat "${FINISH_OUT_1}"
+  echo "FAIL: held finish exited non-zero (must exit 0)" >&2
   exit 1
 fi
-echo "    OK: finish exited 0"
+cat "${FINISH_OUT_1}"
 
-# 2) PR was created as a draft.
 if ! grep -q '^gh pr create .*--draft' "${GH_MOCK_STATE}/gh-calls.log"; then
   echo "FAIL: mock gh never received 'pr create ... --draft'" >&2
   cat "${GH_MOCK_STATE}/gh-calls.log" >&2 || true
   exit 1
 fi
 echo "    OK: PR created as draft"
-
-# 3) No merge was ever attempted.
-if grep -q '^gh pr merge' "${GH_MOCK_STATE}/gh-calls.log"; then
-  echo "FAIL: mock gh received 'pr merge' despite --no-auto-promote" >&2
-  cat "${GH_MOCK_STATE}/gh-calls.log" >&2 || true
+assert_no_real_merge
+echo "    OK: no real gh pr merge call"
+if ! grep -q 'guardex:merge-hold' "${GH_MOCK_STATE}/pr-body"; then
+  echo "FAIL: hold marker not persisted to the PR body" >&2
   exit 1
 fi
-echo "    OK: no gh pr merge call"
-
-# 4) Finish output announced the hold.
-if ! grep -q 'Merge held' "${FINISH_OUT}"; then
-  echo "FAIL: finish output missing the 'Merge held' notice" >&2
+echo "    OK: hold marker persisted on the PR"
+if ! grep -q 'MERGE_HELD=1' "${FINISH_OUT_1}"; then
+  echo "FAIL: held finish did not print the MERGE_HELD=1 trailer" >&2
   exit 1
 fi
-echo "    OK: finish announced the merge hold"
-
-# 5) Agent commit did NOT land on origin's base branch. Checked with ls-tree
-# against the bare origin directly — a clone-based file check silently passes
-# when the bare repo's HEAD doesn't resolve (no checkout, no file).
-if git -C "${ORIGIN_DIR}" ls-tree -r main --name-only | grep -qx "${TRIVIAL_FILE}"; then
-  echo "FAIL: agent file '${TRIVIAL_FILE}' landed on origin/main despite the hold" >&2
-  exit 1
-fi
+echo "    OK: MERGE_HELD=1 trailer printed"
+assert_not_on_base
 echo "    OK: agent commit did not reach origin/main"
 
-# 6) Branch + worktree retained so the gate can run and the finish can rerun.
-if ! git -C "${FIXTURE_REPO}" show-ref --verify --quiet "refs/heads/${AGENT_BRANCH}"; then
-  echo "FAIL: local agent branch was deleted while the merge is held" >&2
+# ---- stage 2: unflagged re-run must NOT lift the hold ----------------------
+echo "==> stage 2: gx branch finish (no flag) — hold must survive"
+FINISH_OUT_2="${SCRATCH}/finish-2.out"
+if ! run_finish "${FINISH_OUT_2}"; then
+  cat "${FINISH_OUT_2}"
+  echo "FAIL: unflagged re-run on a held lane exited non-zero" >&2
   exit 1
 fi
-if ! git -C "${FIXTURE_REPO}" ls-remote --exit-code --heads origin "${AGENT_BRANCH}" >/dev/null 2>&1; then
-  echo "FAIL: remote agent branch was deleted while the merge is held" >&2
+cat "${FINISH_OUT_2}"
+
+if ! grep -q 'merge hold' "${FINISH_OUT_2}"; then
+  echo "FAIL: unflagged re-run did not report the existing merge hold" >&2
   exit 1
 fi
+assert_no_real_merge
+echo "    OK: unflagged re-run attempted no merge"
+if [[ "$(cat "${GH_MOCK_STATE}/pr-draft")" != "true" ]]; then
+  echo "FAIL: unflagged re-run promoted the held draft PR" >&2
+  exit 1
+fi
+echo "    OK: PR still draft, hold not lifted"
+if ! grep -q 'guardex:merge-hold' "${GH_MOCK_STATE}/pr-body"; then
+  echo "FAIL: hold marker vanished on the unflagged re-run" >&2
+  exit 1
+fi
+echo "    OK: hold marker still present"
+assert_not_on_base
+echo "    OK: agent commit still not on origin/main"
 if [[ ! -d "${AGENT_WORKTREE}" ]]; then
   echo "FAIL: agent worktree was pruned while the merge is held" >&2
   exit 1
 fi
-echo "    OK: local branch, remote branch, and worktree retained"
+echo "    OK: worktree retained"
+
+# ---- stage 3: explicit --auto-promote lifts the hold and merges ------------
+echo "==> stage 3: gx branch finish --auto-promote (lift hold)"
+FINISH_OUT_3="${SCRATCH}/finish-3.out"
+if ! run_finish "${FINISH_OUT_3}" --auto-promote; then
+  cat "${FINISH_OUT_3}"
+  echo "FAIL: lifting finish exited non-zero" >&2
+  cat "${GH_MOCK_STATE}/gh-calls.log" >&2 || true
+  exit 1
+fi
+cat "${FINISH_OUT_3}"
+
+if grep -q 'guardex:merge-hold' "${GH_MOCK_STATE}/pr-body"; then
+  echo "FAIL: hold marker still on the PR after --auto-promote" >&2
+  exit 1
+fi
+echo "    OK: hold marker removed"
+if ! git -C "${ORIGIN_DIR}" ls-tree -r main --name-only | grep -qx "${TRIVIAL_FILE}"; then
+  echo "FAIL: agent file did not land on origin/main after the hold was lifted" >&2
+  exit 1
+fi
+echo "    OK: agent commit merged to origin/main"
+if [[ -d "${AGENT_WORKTREE}" ]]; then
+  echo "FAIL: agent worktree still on disk after lifted finish --cleanup" >&2
+  exit 1
+fi
+echo "    OK: worktree pruned after merge"
 
 echo
-echo "PASS: --no-auto-promote held the merge end-to-end (draft PR, no merge, state retained)."
+echo "PASS: merge hold lifecycle — placed, survived an unflagged re-run, lifted only by explicit --auto-promote."

--- a/test/e2e/finish-merge-hold.sh
+++ b/test/e2e/finish-merge-hold.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# e2e smoke test for the `--no-auto-promote` MERGE HOLD in
+# `gx branch finish --via-pr`.
+#
+# Regression under test: run_pr_flow used to run an unconditional
+# `gh pr merge` right after `gh pr create`, so on a repo with no blocking
+# checks the PR landed instantly and `--no-auto-promote` changed nothing.
+# The hold must (a) open the PR as a draft, (b) never attempt a merge,
+# (c) exit 0 with the branch + worktree retained.
+#
+# Same harness as finish-via-pr.sh: local bare origin, bash mock for `gh`
+# injected through `GUARDEX_GH_BIN`, no network.
+#
+# Asserts (all required for PASS):
+#   * `gx branch finish --via-pr --cleanup --no-auto-promote` exits 0.
+#   * The gh mock received `pr create` WITH `--draft`.
+#   * The gh mock NEVER received `pr merge`.
+#   * The finish output announces the merge hold.
+#   * The agent commit did NOT land on origin's base branch.
+#   * The local agent branch, remote agent branch, and worktree all remain.
+
+set -euo pipefail
+
+# ---- locate repo + CLI ----------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd -P)"
+CLI_ENTRY="${REPO_ROOT}/bin/multiagent-safety.js"
+if [[ ! -f "${CLI_ENTRY}" ]]; then
+  echo "FAIL: CLI entry not found at ${CLI_ENTRY}" >&2
+  exit 1
+fi
+
+NODE_BIN_NAME="${NODE_BIN:-node}"
+if ! NODE_BIN_RESOLVED="$(command -v "${NODE_BIN_NAME}" 2>/dev/null)"; then
+  echo "FAIL: node not found in PATH (looked for '${NODE_BIN_NAME}')" >&2
+  exit 1
+fi
+NODE_BIN="${NODE_BIN_RESOLVED}"
+
+export GUARDEX_CLI_ENTRY="${CLI_ENTRY}"
+export GUARDEX_NODE_BIN="${NODE_BIN}"
+
+run_gx() {
+  env \
+    -u CODEX_THREAD_ID \
+    -u OMX_SESSION_ID \
+    -u CODEX_CI \
+    -u CLAUDECODE \
+    -u CLAUDE_CODE_SESSION_ID \
+    -u GUARDEX_AGENT_BRANCH \
+    -u GUARDEX_AGENT_WORKTREE \
+    -u GIT_DIR \
+    -u GIT_WORK_TREE \
+    GUARDEX_HOME_DIR="${GUARDEX_HOME_DIR}" \
+    GUARDEX_CLI_ENTRY="${CLI_ENTRY}" \
+    GUARDEX_NODE_BIN="${NODE_BIN}" \
+    "${NODE_BIN}" "${CLI_ENTRY}" "$@"
+}
+
+# ---- isolated scratch dir -------------------------------------------------
+SCRATCH="$(mktemp -d -t guardex-e2e-hold-XXXXXX)"
+cleanup() {
+  rm -rf "${SCRATCH}" || true
+}
+trap cleanup EXIT
+
+FIXTURE_REPO="${SCRATCH}/fixture"
+ORIGIN_DIR="${SCRATCH}/origin.git"
+MOCK_BIN_DIR="${SCRATCH}/mock-bin"
+export GUARDEX_HOME_DIR="${SCRATCH}/guardex-home"
+mkdir -p "${MOCK_BIN_DIR}" "${GUARDEX_HOME_DIR}"
+
+# ---- gh mock: records calls; a `pr merge` call is the FAILURE signal ------
+GH_MOCK_STATE="${SCRATCH}/gh-mock-state"
+mkdir -p "${GH_MOCK_STATE}"
+cat > "${MOCK_BIN_DIR}/gh" <<'GH_MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+state_dir="${GUARDEX_E2E_GH_STATE:?GUARDEX_E2E_GH_STATE not set}"
+pr_url_file="${state_dir}/pr-url"
+log_file="${state_dir}/gh-calls.log"
+echo "gh $*" >>"${log_file}"
+
+emit_url() {
+  if [[ ! -f "${pr_url_file}" ]]; then
+    echo "https://example.invalid/pr/1" >"${pr_url_file}"
+  fi
+  cat "${pr_url_file}"
+}
+
+case "${1:-}" in
+  pr)
+    shift
+    case "${1:-}" in
+      create)
+        emit_url >/dev/null
+        exit 0
+        ;;
+      view)
+        json_fields=""
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            --json) json_fields="$2"; shift 2 ;;
+            *) shift ;;
+          esac
+        done
+        case "${json_fields}" in
+          url)
+            emit_url
+            ;;
+          isDraft)
+            echo "true"
+            ;;
+          state,mergedAt,url)
+            printf 'OPEN\x1f\x1f%s\n' "$(emit_url)"
+            ;;
+          *)
+            echo "mock-gh: unsupported pr view --json '${json_fields}'" >&2
+            exit 2
+            ;;
+        esac
+        exit 0
+        ;;
+      merge)
+        # The hold must prevent this call entirely. Log already captured it;
+        # fail loudly so a regression cannot silently "merge".
+        echo "mock-gh: pr merge called despite --no-auto-promote hold" >&2
+        exit 2
+        ;;
+      list)
+        printf ''
+        exit 0
+        ;;
+      ready)
+        exit 0
+        ;;
+      *)
+        echo "mock-gh: unsupported pr subcommand '${1:-}'" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  *)
+    echo "mock-gh: unsupported top-level '${1:-}'" >&2
+    exit 2
+    ;;
+esac
+GH_MOCK
+chmod +x "${MOCK_BIN_DIR}/gh"
+
+# ---- build fixture repo + bare origin -----------------------------------
+mkdir -p "${FIXTURE_REPO}"
+git init --quiet --initial-branch=main "${FIXTURE_REPO}"
+git -C "${FIXTURE_REPO}" config user.email "e2e-bot@example.invalid"
+git -C "${FIXTURE_REPO}" config user.name "guardex-e2e"
+cat >"${FIXTURE_REPO}/package.json" <<JSON
+{
+  "name": "guardex-e2e-hold-fixture",
+  "version": "0.0.0",
+  "private": true
+}
+JSON
+git -C "${FIXTURE_REPO}" add package.json
+git -C "${FIXTURE_REPO}" commit --quiet -m "seed"
+
+git init --quiet --bare "${ORIGIN_DIR}"
+git -C "${FIXTURE_REPO}" remote add origin "${ORIGIN_DIR}"
+git -C "${FIXTURE_REPO}" push --quiet -u origin main
+
+# ---- run `gx setup` ------------------------------------------------------
+echo "==> gx setup"
+run_gx setup --target "${FIXTURE_REPO}" --no-global-install
+
+git -C "${FIXTURE_REPO}" add -A
+ALLOW_COMMIT_ON_PROTECTED_BRANCH=1 git -C "${FIXTURE_REPO}" commit --quiet -m "apply gx setup"
+ALLOW_PUSH_ON_PROTECTED_BRANCH=1 git -C "${FIXTURE_REPO}" push --quiet origin main
+
+# ---- run `gx branch start` ----------------------------------------------
+echo "==> gx branch start"
+BRANCH_START_OUT="${SCRATCH}/branch-start.out"
+(
+  cd "${FIXTURE_REPO}"
+  run_gx branch start --tier T1 e2e-hold bot
+) >"${BRANCH_START_OUT}" 2>&1
+cat "${BRANCH_START_OUT}"
+
+AGENT_BRANCH="$(grep -oE '\[agent-branch-start\] Created branch: .+' "${BRANCH_START_OUT}" | head -1 | sed 's/^\[agent-branch-start\] Created branch: //')"
+AGENT_WORKTREE="$(grep -oE '\[agent-branch-start\] Worktree: .+' "${BRANCH_START_OUT}" | head -1 | sed 's/^\[agent-branch-start\] Worktree: //')"
+if [[ -z "${AGENT_BRANCH}" || -z "${AGENT_WORKTREE}" ]]; then
+  echo "FAIL: could not parse agent branch/worktree from gx branch start output" >&2
+  exit 1
+fi
+echo "    agent branch:   ${AGENT_BRANCH}"
+echo "    agent worktree: ${AGENT_WORKTREE}"
+
+# ---- commit a trivial change inside the agent worktree -------------------
+echo "==> commit trivial change in agent worktree"
+TRIVIAL_FILE="e2e-hold-marker.txt"
+echo "guardex e2e: this file must NOT land on base while the merge is held." \
+  >"${AGENT_WORKTREE}/${TRIVIAL_FILE}"
+
+(
+  cd "${FIXTURE_REPO}"
+  run_gx locks claim --branch "${AGENT_BRANCH}" "${TRIVIAL_FILE}"
+)
+
+git -C "${AGENT_WORKTREE}" add "${TRIVIAL_FILE}"
+git -C "${AGENT_WORKTREE}" commit --quiet -m "e2e: change held behind --no-auto-promote"
+
+# ---- run `gx branch finish --via-pr --cleanup --no-auto-promote` ----------
+echo "==> gx branch finish --via-pr --cleanup --no-auto-promote"
+FINISH_OUT="${SCRATCH}/branch-finish.out"
+set +e
+(
+  cd "${FIXTURE_REPO}"
+  env \
+    -u CODEX_THREAD_ID \
+    -u OMX_SESSION_ID \
+    -u CODEX_CI \
+    -u CLAUDECODE \
+    -u CLAUDE_CODE_SESSION_ID \
+    -u GUARDEX_AGENT_BRANCH \
+    -u GUARDEX_AGENT_WORKTREE \
+    -u GIT_DIR \
+    -u GIT_WORK_TREE \
+    PATH="${MOCK_BIN_DIR}:${PATH}" \
+    GUARDEX_GH_BIN="${MOCK_BIN_DIR}/gh" \
+    GUARDEX_E2E_GH_STATE="${GH_MOCK_STATE}" \
+    GUARDEX_HOME_DIR="${GUARDEX_HOME_DIR}" \
+    GUARDEX_CLI_ENTRY="${CLI_ENTRY}" \
+    GUARDEX_NODE_BIN="${NODE_BIN}" \
+    "${NODE_BIN}" "${CLI_ENTRY}" branch finish \
+    --branch "${AGENT_BRANCH}" \
+    --base main \
+    --via-pr \
+    --cleanup \
+    --no-auto-promote
+) >"${FINISH_OUT}" 2>&1
+FINISH_STATUS=$?
+set -e
+cat "${FINISH_OUT}"
+
+# ---- assertions ----------------------------------------------------------
+echo "==> assertions"
+
+# 1) Held finish exits 0 (intentional hold, not a failure).
+if [[ "${FINISH_STATUS}" -ne 0 ]]; then
+  echo "FAIL: gx branch finish exited with status ${FINISH_STATUS} (held merge must exit 0)" >&2
+  echo "---- gh mock call log ----" >&2
+  cat "${GH_MOCK_STATE}/gh-calls.log" >&2 || true
+  exit 1
+fi
+echo "    OK: finish exited 0"
+
+# 2) PR was created as a draft.
+if ! grep -q '^gh pr create .*--draft' "${GH_MOCK_STATE}/gh-calls.log"; then
+  echo "FAIL: mock gh never received 'pr create ... --draft'" >&2
+  cat "${GH_MOCK_STATE}/gh-calls.log" >&2 || true
+  exit 1
+fi
+echo "    OK: PR created as draft"
+
+# 3) No merge was ever attempted.
+if grep -q '^gh pr merge' "${GH_MOCK_STATE}/gh-calls.log"; then
+  echo "FAIL: mock gh received 'pr merge' despite --no-auto-promote" >&2
+  cat "${GH_MOCK_STATE}/gh-calls.log" >&2 || true
+  exit 1
+fi
+echo "    OK: no gh pr merge call"
+
+# 4) Finish output announced the hold.
+if ! grep -q 'Merge held' "${FINISH_OUT}"; then
+  echo "FAIL: finish output missing the 'Merge held' notice" >&2
+  exit 1
+fi
+echo "    OK: finish announced the merge hold"
+
+# 5) Agent commit did NOT land on origin's base branch. Checked with ls-tree
+# against the bare origin directly — a clone-based file check silently passes
+# when the bare repo's HEAD doesn't resolve (no checkout, no file).
+if git -C "${ORIGIN_DIR}" ls-tree -r main --name-only | grep -qx "${TRIVIAL_FILE}"; then
+  echo "FAIL: agent file '${TRIVIAL_FILE}' landed on origin/main despite the hold" >&2
+  exit 1
+fi
+echo "    OK: agent commit did not reach origin/main"
+
+# 6) Branch + worktree retained so the gate can run and the finish can rerun.
+if ! git -C "${FIXTURE_REPO}" show-ref --verify --quiet "refs/heads/${AGENT_BRANCH}"; then
+  echo "FAIL: local agent branch was deleted while the merge is held" >&2
+  exit 1
+fi
+if ! git -C "${FIXTURE_REPO}" ls-remote --exit-code --heads origin "${AGENT_BRANCH}" >/dev/null 2>&1; then
+  echo "FAIL: remote agent branch was deleted while the merge is held" >&2
+  exit 1
+fi
+if [[ ! -d "${AGENT_WORKTREE}" ]]; then
+  echo "FAIL: agent worktree was pruned while the merge is held" >&2
+  exit 1
+fi
+echo "    OK: local branch, remote branch, and worktree retained"
+
+echo
+echo "PASS: --no-auto-promote held the merge end-to-end (draft PR, no merge, state retained)."

--- a/test/e2e/finish-via-pr.sh
+++ b/test/e2e/finish-via-pr.sh
@@ -161,6 +161,11 @@ case "${1:-}" in
           url)
             emit_url
             ;;
+          body)
+            # No hold marker in this scenario; the finish flow reads the body
+            # to check for guardex:merge-hold before promoting/merging.
+            printf '\n'
+            ;;
           state,mergedAt,url)
             if [[ -f "${merge_marker}" ]]; then
               printf 'MERGED\x1f2026-01-01T00:00:00Z\x1f%s\n' "$(emit_url)"

--- a/test/finish-preflight-flag.test.js
+++ b/test/finish-preflight-flag.test.js
@@ -91,16 +91,59 @@ test('--no-auto-promote forces the PR path and refuses --direct-only', () => {
   );
 });
 
-test('held merge exits 0 with the worktree retained', () => {
+test('held merge exits 0 with the worktree retained and a machine-readable trailer', () => {
   assert.ok(
     script.includes('"$MERGE_HELD" -eq 1'),
     'the pr_exit=2 handler must branch on MERGE_HELD',
   );
-  const heldIdx = script.indexOf('Merge held by --no-auto-promote');
+  const heldIdx = script.indexOf('Merge hold active');
   assert.notEqual(heldIdx, -1, 'held exit must explain how to lift the hold');
+  assert.ok(
+    script.indexOf('echo "MERGE_HELD=1"', heldIdx) !== -1,
+    'held exit must print the MERGE_HELD=1 trailer so automation can tell held from merged',
+  );
   const exitIdx = script.indexOf('exit 0', heldIdx);
   assert.ok(
     exitIdx !== -1 && exitIdx - heldIdx < 400,
     'held merge must exit 0 right after the held message (intentional hold, not a failure)',
   );
+});
+
+// The hold must survive UNFLAGGED re-runs (stop hook, doctor sweep,
+// `gx finish --all`): a persisted marker in the PR body is checked BEFORE the
+// draft promotion and the merge, and only an explicit --auto-promote lifts it.
+test('persisted hold marker is honored before promotion and merge', () => {
+  const flowIdx = script.indexOf('run_pr_flow() {');
+  const flow = script.slice(flowIdx);
+  const markerIdx = flow.indexOf('pr_has_hold_marker "$pr_url"');
+  const promoteIdx = flow.indexOf('maybe_auto_promote_pr "$pr_url"');
+  const mergeIdx = flow.indexOf('pr merge "$SOURCE_BRANCH" --squash --delete-branch');
+  assert.notEqual(markerIdx, -1, 'run_pr_flow must check the persisted hold marker');
+  assert.ok(
+    markerIdx < promoteIdx,
+    'marker check must come BEFORE draft promotion, else an unflagged re-run lifts the hold',
+  );
+  assert.ok(
+    markerIdx < mergeIdx,
+    'marker check must come BEFORE the immediate merge',
+  );
+  assert.ok(
+    flow.includes('"$AUTO_PROMOTE_EXPLICIT" -eq 1'),
+    'only an EXPLICIT --auto-promote may lift the marker (env default must not)',
+  );
+  assert.ok(
+    script.includes('AUTO_PROMOTE_EXPLICIT=1'),
+    '--auto-promote must record explicitness',
+  );
+});
+
+test('placing the hold disarms auto-merge and demotes a ready PR', () => {
+  const flowIdx = script.indexOf('run_pr_flow() {');
+  const flow = script.slice(flowIdx);
+  const disarmIdx = flow.indexOf('--disable-auto');
+  const demoteIdx = flow.indexOf('pr ready --undo');
+  const placeIdx = flow.indexOf('place_hold_marker "$pr_url"');
+  assert.notEqual(disarmIdx, -1, 'hold must disarm previously-enabled GitHub auto-merge');
+  assert.notEqual(demoteIdx, -1, 'hold must demote a pre-existing ready PR back to draft');
+  assert.notEqual(placeIdx, -1, 'hold must persist the marker on the PR body');
 });

--- a/test/finish-preflight-flag.test.js
+++ b/test/finish-preflight-flag.test.js
@@ -115,7 +115,7 @@ test('held merge exits 0 with the worktree retained and a machine-readable trail
 test('persisted hold marker is honored before promotion and merge', () => {
   const flowIdx = script.indexOf('run_pr_flow() {');
   const flow = script.slice(flowIdx);
-  const markerIdx = flow.indexOf('pr_has_hold_marker "$pr_url"');
+  const markerIdx = flow.indexOf('pr_hold_marker_state "$pr_url"');
   const promoteIdx = flow.indexOf('maybe_auto_promote_pr "$pr_url"');
   const mergeIdx = flow.indexOf('pr merge "$SOURCE_BRANCH" --squash --delete-branch');
   assert.notEqual(markerIdx, -1, 'run_pr_flow must check the persisted hold marker');
@@ -134,6 +134,21 @@ test('persisted hold marker is honored before promotion and merge', () => {
   assert.ok(
     script.includes('AUTO_PROMOTE_EXPLICIT=1'),
     '--auto-promote must record explicitness',
+  );
+  assert.ok(
+    flow.includes('treating the PR as held (fail closed)'),
+    'an unreadable PR body must fail CLOSED in the PR flow, not silently lift the hold',
+  );
+});
+
+test('persisted hold marker also stops the direct-push shortcut', () => {
+  const guardIdx = script.indexOf('pr_hold_marker_state "$SOURCE_BRANCH"');
+  const directPushIdx = script.indexOf('push origin "HEAD:${BASE_BRANCH}"');
+  assert.notEqual(guardIdx, -1, 'direct-push path must consult the hold marker');
+  assert.notEqual(directPushIdx, -1, 'direct push must exist');
+  assert.ok(
+    guardIdx < directPushIdx,
+    'the marker check must run BEFORE the direct push, or auto/direct-mode reruns land held work',
   );
 });
 

--- a/test/finish-preflight-flag.test.js
+++ b/test/finish-preflight-flag.test.js
@@ -47,3 +47,60 @@ test('--no-auto-promote is honored: AUTO_PROMOTE_DRAFT normalized after the pars
     'auto-promote',
   );
 });
+
+// --no-auto-promote is a MERGE HOLD, not just a promote skip. run_pr_flow's
+// immediate `gh pr merge` lands the PR the instant the repo has no blocking
+// checks, so the hold must early-return BEFORE that call. Ordering is checked
+// statically, same rationale as above.
+test('--no-auto-promote holds the merge: early return before the immediate gh pr merge', () => {
+  const flowIdx = script.indexOf('run_pr_flow() {');
+  assert.notEqual(flowIdx, -1, 'run_pr_flow must exist');
+  const flow = script.slice(flowIdx);
+  const holdIdx = flow.indexOf('MERGE_HELD=1');
+  const mergeIdx = flow.indexOf('pr merge "$SOURCE_BRANCH" --squash --delete-branch');
+  assert.notEqual(holdIdx, -1, 'run_pr_flow must set MERGE_HELD=1 when auto-promote is off');
+  assert.notEqual(mergeIdx, -1, 'run_pr_flow must contain the immediate merge attempt');
+  assert.ok(
+    holdIdx < mergeIdx,
+    'merge-hold early return must come BEFORE the immediate gh pr merge, else the PR lands instantly',
+  );
+});
+
+test('--no-auto-promote opens the PR as a draft (with ready fallback)', () => {
+  assert.ok(
+    script.includes('pr_create_args+=(--draft)'),
+    'pr create must add --draft when auto-promote is off',
+  );
+  assert.ok(
+    script.includes('draft pull requests are not supported'),
+    'draft-unsupported plans must fall back to a ready PR (hold still applies)',
+  );
+});
+
+test('--no-auto-promote forces the PR path and refuses --direct-only', () => {
+  assert.ok(
+    script.includes('cannot be combined with --direct-only'),
+    'hold + --direct-only must be refused (a direct push has no PR to hold)',
+  );
+  const normIdx = script.indexOf('AUTO_PROMOTE_DRAFT="$(normalize_bool');
+  const guardIdx = script.indexOf('MERGE_HELD=0');
+  assert.notEqual(guardIdx, -1, 'MERGE_HELD must be initialized');
+  assert.ok(
+    guardIdx > normIdx,
+    'the hold/mode guard must run AFTER AUTO_PROMOTE_DRAFT normalization or the flag is ignored',
+  );
+});
+
+test('held merge exits 0 with the worktree retained', () => {
+  assert.ok(
+    script.includes('"$MERGE_HELD" -eq 1'),
+    'the pr_exit=2 handler must branch on MERGE_HELD',
+  );
+  const heldIdx = script.indexOf('Merge held by --no-auto-promote');
+  assert.notEqual(heldIdx, -1, 'held exit must explain how to lift the hold');
+  const exitIdx = script.indexOf('exit 0', heldIdx);
+  assert.ok(
+    exitIdx !== -1 && exitIdx - heldIdx < 400,
+    'held merge must exit 0 right after the held message (intentional hold, not a failure)',
+  );
+});

--- a/test/finish.test.js
+++ b/test/finish.test.js
@@ -411,6 +411,10 @@ if [[ "$1" == "pr" && "$2" == "create" ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ " $* " == *" --json body "* ]]; then
+    echo ""
+    exit 0
+  fi
   if [[ " $* " == *" --json url "* ]]; then
     echo "https://example.test/pr/1"
     exit 0
@@ -475,6 +479,10 @@ if [[ "$1" == "pr" && "$2" == "create" ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ " $* " == *" --json body "* ]]; then
+    echo ""
+    exit 0
+  fi
   if [[ " $* " == *" --json url "* ]]; then
     echo "https://example.test/pr/skip-integrate"
     exit 0
@@ -548,6 +556,10 @@ if [[ "$1" == "pr" && "$2" == "create" ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ " $* " == *" --json body "* ]]; then
+    echo ""
+    exit 0
+  fi
   if [[ " $* " == *" --json url "* ]]; then
     echo "https://example.test/pr/2"
     exit 0
@@ -625,6 +637,10 @@ if [[ "$1" == "pr" && "$2" == "create" ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ " $* " == *" --json body "* ]]; then
+    echo ""
+    exit 0
+  fi
   if [[ " $* " == *" --json url "* ]]; then
     echo "https://example.test/pr/remote-delete-rejected"
     exit 0
@@ -710,6 +726,10 @@ if [[ "$1" == "pr" && "$2" == "create" ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ " $* " == *" --json body "* ]]; then
+    echo ""
+    exit 0
+  fi
   if [[ " $* " == *" --json url "* ]]; then
     echo "https://example.test/pr/local-delete-race"
     exit 0
@@ -946,6 +966,10 @@ if [[ "$1" == "pr" && "$2" == "create" ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ " $* " == *" --json body "* ]]; then
+    echo ""
+    exit 0
+  fi
   if [[ " $* " == *" --json url "* ]]; then
     echo "https://example.test/pr/active-cleanup"
     exit 0
@@ -1009,6 +1033,10 @@ if [[ "$1" == "pr" && "$2" == "create" ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ " $* " == *" --json body "* ]]; then
+    echo ""
+    exit 0
+  fi
   if [[ " $* " == *" --json url "* ]]; then
     echo "https://example.test/pr/2"
     exit 0
@@ -1108,6 +1136,10 @@ if [[ "$1" == "pr" && "$2" == "create" ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ " $* " == *" --json body "* ]]; then
+    echo ""
+    exit 0
+  fi
   if [[ " $* " == *" --json url "* ]]; then
     echo "https://example.test/pr/default"
     exit 0


### PR DESCRIPTION
Automated by gx branch finish (PR flow).