### PR TITLE
fix(gate): refuse to merge on a review that was never posted

### DIFF
--- a/openspec/changes/agent-claude-gate-require-posted-review-2026-08-07-16-37/.openspec.yaml
+++ b/openspec/changes/agent-claude-gate-require-posted-review-2026-08-07-16-37/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-07

--- a/openspec/changes/agent-claude-gate-require-posted-review-2026-08-07-16-37/proposal.md
+++ b/openspec/changes/agent-claude-gate-require-posted-review-2026-08-07-16-37/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+`--gate-review` merged three PRs in `Webu-PRO/lifted.sk-storefront` — #463,
+#465 and #466 — each carrying **zero reviews and zero comments**, after
+announcing `enforcing review + CI gate before merge`. The reviewer itself was
+fine: run by hand over #465's merged diff it produced four findings, two of
+them real defects that had already shipped.
+
+The gate treats an unposted review as a pass. `runPrReview` can return
+`posted: false` — GitHub auth unavailable to the runner, or any path that
+writes a local artifact instead of posting — and the gate only appends
+`[not posted: …]` to a log line before promoting the PR and merging it.
+
+That makes two failures indistinguishable from success:
+
+- a provider that returned nothing looks exactly like a clean review;
+- a verdict that never reached the PR leaves nothing to audit afterwards. The
+  merge is recorded; the reasoning is not.
+
+## What Changes
+
+The gate now requires evidence. `!review.posted` throws instead of logging,
+before `markReady`, so an unposted review neither promotes nor merges the PR.
+The error names the cause (auth vs. a runner that reported not-posted) and the
+local artifact path, so the operator can read what the provider actually said
+before re-running or passing `--skip-review-gate`.
+
+The success log now says `posted to the PR`, so the line means what it claims.
+
+## Impact
+
+- `src/finish/review-gate.js` — one guard.
+- Every `runPrReview` stub across the gate test harnesses now returns
+  `posted: true`, because they all stand for a review that reached the PR. The
+  three new tests are the only ones that opt out. Without this the default stub
+  silently modelled the broken case.
+- 858 tests, 41 failures — byte-identical to the pre-change failing set, so no
+  new failures. Those 41 are pre-existing.
+- **This is a guard, not a root cause.** It closes the hole that let those
+  three PRs through, and fails closed either way, but why the runner reported
+  not-posted on that machine is still open: `gh auth status` succeeds in an
+  interactive shell, so the likely difference is the environment the review
+  subprocess inherits. Worth chasing separately.

--- a/openspec/changes/agent-claude-gate-require-posted-review-2026-08-07-16-37/specs/gate-require-posted-review/spec.md
+++ b/openspec/changes/agent-claude-gate-require-posted-review-2026-08-07-16-37/specs/gate-require-posted-review/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: The merge gate requires a posted review
+A review that did not reach the pull request SHALL NOT satisfy the gate. The
+gate exists to put a verdict on the record, and an in-memory verdict cannot be
+audited or distinguished from a provider that returned nothing.
+
+#### Scenario: An unposted review blocks the merge
+- **WHEN** the review runner reports that it did not post
+- **THEN** the gate throws before promoting the PR out of draft
+- **AND** the PR is neither marked ready nor merged.
+
+#### Scenario: Zero findings do not excuse an unposted review
+- **WHEN** the review reports no findings and was not posted
+- **THEN** the gate still blocks.
+
+#### Scenario: The operator is told why and where to look
+- **WHEN** the gate blocks on an unposted review
+- **THEN** the error names the reported cause
+- **AND** includes the local artifact path when the runner wrote one.

--- a/openspec/changes/agent-claude-gate-require-posted-review-2026-08-07-16-37/tasks.md
+++ b/openspec/changes/agent-claude-gate-require-posted-review-2026-08-07-16-37/tasks.md
@@ -1,0 +1,34 @@
+## Definition of Done
+
+This change is complete only when **all** of the following are true:
+
+- Every checkbox below is checked.
+- The agent branch reaches `MERGED` state on `origin` and the PR URL + state are recorded in the completion handoff.
+- If any step blocks (test failure, conflict, ambiguous result), append a `BLOCKED:` line under section 4 explaining the blocker and **STOP**. Do not tick remaining cleanup boxes; do not silently skip the cleanup pipeline.
+
+## Handoff
+
+- Handoff: change=`agent-claude-gate-require-posted-review-2026-08-07-16-37`; branch=`agent/<your-name>/<branch-slug>`; scope=`TODO`; action=`continue this sandbox or finish cleanup after a usage-limit/manual takeover`.
+- Copy prompt: Continue `agent-claude-gate-require-posted-review-2026-08-07-16-37` on branch `agent/<your-name>/<branch-slug>`. Work inside the existing sandbox, review `openspec/changes/agent-claude-gate-require-posted-review-2026-08-07-16-37/tasks.md`, continue from the current state instead of creating a new sandbox, and when the work is done run `gx branch finish --branch agent/<your-name>/<branch-slug> --base main --via-pr --gate-review --review-provider claude --wait-for-merge --cleanup`.
+
+## 1. Specification
+
+- [ ] 1.1 Finalize proposal scope and acceptance criteria for `agent-claude-gate-require-posted-review-2026-08-07-16-37`.
+- [ ] 1.2 Define normative requirements in `specs/gate-require-posted-review/spec.md`.
+
+## 2. Implementation
+
+- [ ] 2.1 Implement scoped behavior changes.
+- [ ] 2.2 Add/update focused regression coverage.
+
+## 3. Verification
+
+- [ ] 3.1 Run targeted project verification commands.
+- [ ] 3.2 Run `openspec validate agent-claude-gate-require-posted-review-2026-08-07-16-37 --type change --strict`.
+- [ ] 3.3 Run `openspec validate --specs`.
+
+## 4. Cleanup (mandatory; run before claiming completion)
+
+- [ ] 4.1 Run the cleanup pipeline: `gx branch finish --branch agent/<your-name>/<branch-slug> --base main --via-pr --gate-review --review-provider claude --wait-for-merge --cleanup`. This handles commit -> push -> PR create -> merge wait -> worktree prune in one invocation.
+- [ ] 4.2 Record the PR URL and final merge state (`MERGED`) in the completion handoff.
+- [ ] 4.3 Confirm the sandbox worktree is gone (`git worktree list` no longer shows the agent path; `git branch -a` shows no surviving local/remote refs for the branch).

--- a/src/finish/review-gate.js
+++ b/src/finish/review-gate.js
@@ -28,6 +28,29 @@ function gateLog(message) {
   console.log(`[${TOOL_NAME}] [gate] ${message}`);
 }
 
+/**
+ * A review that never reached the PR does not count as a review.
+ *
+ * `runPrReview` can come back `posted: false` — GitHub auth unavailable to the
+ * runner, or any path that writes a local artifact instead of posting. Treating
+ * that as a pass makes two failures look like success: an in-memory verdict
+ * cannot be audited after the merge, and a provider that returned nothing is
+ * indistinguishable from a clean review.
+ */
+function requirePostedReview(review, prNumber) {
+  if (review.posted) return;
+  const why = review.reason === 'github-auth-unavailable'
+    ? 'GitHub auth was unavailable to the review runner'
+    : `the review runner reported posted=${JSON.stringify(review.posted)}`;
+  throw new Error(
+    `review gate: the AI review was not posted to PR #${prNumber} (${why}). Refusing to merge — `
+    + 'an unposted review leaves no evidence the diff was examined, and a provider that returns '
+    + 'nothing then looks exactly like a clean pass.'
+    + (review.artifactPath ? `\nLocal artifact: ${review.artifactPath}` : '')
+    + '\nFix the provider/auth issue and re-run, or bypass with --skip-review-gate.',
+  );
+}
+
 /** Worktree holding `branch`, or `repoRoot` when git cannot tell us. */
 function resolveWorktreeForBranch(repoRoot, branch) {
   try {
@@ -214,6 +237,20 @@ function runReviewGate({
         + 'Fix the provider/auth issue or rerun with --skip-review-gate.',
       );
     }
+    // Evidence check, before anything is spent on this review. A review that
+    // did not reach the PR cannot be audited afterwards, and a provider that
+    // returned nothing then looks exactly like a clean pass — which is how
+    // lifted.sk-storefront #463, #465 and #466 each merged carrying zero
+    // reviews while this gate announced it was enforcing one.
+    //
+    // Here rather than after the loop: `posted` is known the moment the first
+    // review returns and its cause does not change between rounds, so deferring
+    // would burn every --gate-autofix round and push agent-authored fix commits
+    // before refusing. It also keeps the error honest when the review is both
+    // unposted and dirty, where the blocking-findings message would otherwise
+    // send the operator to a PR that has no review on it.
+    requirePostedReview(review, prNumber);
+
     verdict = evaluate(review.findings);
     for (const finding of verdict.blocking) {
       if (finding && finding.path) blockedPaths.add(finding.path);
@@ -269,28 +306,6 @@ function runReviewGate({
       + '\nRe-run the review, fix these by hand, or bypass with --skip-review-gate.',
     );
   }
-  // The review must leave evidence on the PR. A verdict that exists only in
-  // this process's memory cannot be audited afterwards, and "clean" becomes
-  // indistinguishable from "the provider returned nothing" — which is how
-  // lifted.sk-storefront #463, #465 and #466 each merged carrying zero reviews
-  // while the gate had announced it was enforcing one.
-  //
-  // Fail closed, in keeping with the rest of this gate: a review that was not
-  // posted is not a review. The artifact path is surfaced so the operator can
-  // read what the provider actually said before re-running or bypassing.
-  if (!review.posted) {
-    const why = review.reason === 'github-auth-unavailable'
-      ? 'GitHub auth was unavailable to the review runner'
-      : `the review runner reported posted=${JSON.stringify(review.posted)}`;
-    throw new Error(
-      `review gate: the AI review was not posted to PR #${prNumber} (${why}). Refusing to merge — `
-      + 'an unposted review leaves no evidence the diff was examined, and a provider that returns '
-      + 'nothing then looks exactly like a clean pass.'
-      + (review.artifactPath ? `\nLocal artifact: ${review.artifactPath}` : '')
-      + '\nFix the provider/auth issue and re-run, or bypass with --skip-review-gate.',
-    );
-  }
-
   gateLog(
     `PR #${prNumber}: review clean (${review.findings.length} non-blocking finding(s)), posted to the PR`,
   );

--- a/src/finish/review-gate.js
+++ b/src/finish/review-gate.js
@@ -269,9 +269,30 @@ function runReviewGate({
       + '\nRe-run the review, fix these by hand, or bypass with --skip-review-gate.',
     );
   }
+  // The review must leave evidence on the PR. A verdict that exists only in
+  // this process's memory cannot be audited afterwards, and "clean" becomes
+  // indistinguishable from "the provider returned nothing" — which is how
+  // lifted.sk-storefront #463, #465 and #466 each merged carrying zero reviews
+  // while the gate had announced it was enforcing one.
+  //
+  // Fail closed, in keeping with the rest of this gate: a review that was not
+  // posted is not a review. The artifact path is surfaced so the operator can
+  // read what the provider actually said before re-running or bypassing.
+  if (!review.posted) {
+    const why = review.reason === 'github-auth-unavailable'
+      ? 'GitHub auth was unavailable to the review runner'
+      : `the review runner reported posted=${JSON.stringify(review.posted)}`;
+    throw new Error(
+      `review gate: the AI review was not posted to PR #${prNumber} (${why}). Refusing to merge — `
+      + 'an unposted review leaves no evidence the diff was examined, and a provider that returns '
+      + 'nothing then looks exactly like a clean pass.'
+      + (review.artifactPath ? `\nLocal artifact: ${review.artifactPath}` : '')
+      + '\nFix the provider/auth issue and re-run, or bypass with --skip-review-gate.',
+    );
+  }
+
   gateLog(
-    `PR #${prNumber}: review clean (${review.findings.length} non-blocking finding(s))`
-    + (review.reason === 'github-auth-unavailable' ? ' [not posted: github-auth-unavailable]' : ''),
+    `PR #${prNumber}: review clean (${review.findings.length} non-blocking finding(s)), posted to the PR`,
   );
 
   // 3. Promote draft -> ready so required CI checks fire.

--- a/test/gate-baseline.test.js
+++ b/test/gate-baseline.test.js
@@ -188,7 +188,7 @@ test('baselineFailures reports unavailable when nothing anywhere has checks', ()
 function gateDeps(overrides = {}) {
   return {
     openPullRequest: () => ({ pr: { number: 7 } }),
-    runPrReview: () => ({ findings: [] }),
+    runPrReview: () => ({ findings: [], posted: true }),
     markPullRequestReady: () => {},
     ...overrides,
   };

--- a/test/gate-carry-forward.test.js
+++ b/test/gate-carry-forward.test.js
@@ -54,7 +54,7 @@ test('a blocking finding that silently vanishes after an unrelated fix blocks th
   const deps = gateDeps({
     runPrReview: () => {
       round += 1;
-      return { findings: round === 1 ? [HIGH, OTHER_HIGH] : [] };
+      return { findings: round === 1 ? [HIGH, OTHER_HIGH] : [], posted: true };
     },
     runReviewFix: () => ({ status: 'fixed', changedFiles: ['src/pages/store.tsx'], sha: 'abc' }),
   });
@@ -72,7 +72,7 @@ test('a blocking finding whose file the fix actually edited clears normally', ()
   const deps = gateDeps({
     runPrReview: () => {
       round += 1;
-      return { findings: round === 1 ? [HIGH] : [] };
+      return { findings: round === 1 ? [HIGH] : [], posted: true };
     },
     runReviewFix: () => ({
       status: 'fixed', changedFiles: ['src/components/product-card-compact.tsx'], sha: 'abc',
@@ -88,7 +88,7 @@ test('a finding downgraded below the block threshold still counts as reviewed', 
   const deps = gateDeps({
     runPrReview: () => {
       round += 1;
-      return { findings: round === 1 ? [HIGH] : [{ ...HIGH, severity: 'medium' }] };
+      return { findings: round === 1 ? [HIGH] : [{ ...HIGH, severity: 'medium' }], posted: true };
     },
     runReviewFix: () => ({ status: 'fixed', changedFiles: ['unrelated.ts'], sha: 'abc' }),
   });
@@ -99,7 +99,7 @@ test('carry-forward never fires without --gate-autofix', () => {
   // One review round only, so there is no later round for a finding to vanish
   // from. Behavior must be byte-identical to before this change.
   const deps = gateDeps({
-    runPrReview: () => ({ findings: [] }),
+    runPrReview: () => ({ findings: [], posted: true }),
     runReviewFix: () => assert.fail('no fix without the flag'),
   });
   assert.deepEqual(gate(deps, {}), { prNumber: 440 });
@@ -107,7 +107,7 @@ test('carry-forward never fires without --gate-autofix', () => {
 
 test('a clean first review merges even with autofix armed', () => {
   const deps = gateDeps({
-    runPrReview: () => ({ findings: [{ path: 'a.tsx', line: 1, severity: 'low', message: 'nit' }] }),
+    runPrReview: () => ({ findings: [{ path: 'a.tsx', line: 1, severity: 'low', message: 'nit' }], posted: true }),
     runReviewFix: () => assert.fail('nothing blocking, nothing to fix'),
   });
   assert.deepEqual(gate(deps, { gateAutofix: true }), { prNumber: 440 });
@@ -115,7 +115,7 @@ test('a clean first review merges even with autofix armed', () => {
 
 test('an aborted fix still blocks on the original finding, not the carry-forward path', () => {
   const deps = gateDeps({
-    runPrReview: () => ({ findings: [HIGH] }),
+    runPrReview: () => ({ findings: [HIGH], posted: true }),
     runReviewFix: () => ({ status: 'no-op', changedFiles: [], reason: 'provider made no edits' }),
   });
   assert.throws(() => gate(deps, { gateAutofix: true }), /1 blocking finding/);

--- a/test/review-fix.test.js
+++ b/test/review-fix.test.js
@@ -124,7 +124,7 @@ function gateDeps(overrides = {}) {
 
 test('gate without --gate-autofix blocks on a high finding and never runs a fix', () => {
   const deps = gateDeps({
-    runPrReview: () => ({ findings: [FINDING] }),
+    runPrReview: () => ({ findings: [FINDING], posted: true }),
     runReviewFix: () => assert.fail('auto-fix must be opt-in'),
   });
   assert.throws(
@@ -138,7 +138,7 @@ test('gate with --gate-autofix repairs, pushes, re-reviews, and then merges', ()
   const deps = gateDeps({
     runPrReview: () => {
       calls.reviews += 1;
-      return { findings: calls.reviews === 1 ? [FINDING] : [] };
+      return { findings: calls.reviews === 1 ? [FINDING] : [], posted: true };
     },
     runReviewFix: (args) => {
       calls.fixes += 1;
@@ -165,7 +165,7 @@ test('gate with --gate-autofix repairs, pushes, re-reviews, and then merges', ()
 test('gate stops fixing after the round budget and still blocks', () => {
   let fixes = 0;
   const deps = gateDeps({
-    runPrReview: () => ({ findings: [FINDING] }),
+    runPrReview: () => ({ findings: [FINDING], posted: true }),
     runReviewFix: () => {
       fixes += 1;
       return { status: 'fixed', changedFiles: ['src/a.js'], sha: 'abc' };
@@ -183,7 +183,7 @@ test('gate stops fixing after the round budget and still blocks', () => {
 test('gate falls through to the block when the fix changes nothing', () => {
   let fixes = 0;
   const deps = gateDeps({
-    runPrReview: () => ({ findings: [FINDING] }),
+    runPrReview: () => ({ findings: [FINDING], posted: true }),
     runReviewFix: () => {
       fixes += 1;
       return { status: 'no-op', changedFiles: [], reason: 'provider made no edits' };

--- a/test/review-gate.test.js
+++ b/test/review-gate.test.js
@@ -172,7 +172,7 @@ test('waitForGreenCi times out when CI never settles', () => {
 function gateDeps(over = {}) {
   return {
     openPullRequest: () => ({ pr: { number: 42 } }),
-    runPrReview: () => ({ findings: [] }),
+    runPrReview: () => ({ findings: [], posted: true }),
     markPullRequestReady: () => {},
     evaluateReviewGate, // real
     waitForGreenCi: () => ({ status: 'green', pr: { mergeStateStatus: 'CLEAN' } }),
@@ -192,7 +192,7 @@ test('runReviewGate fails CLOSED when the AI review provider throws', () => {
 
 test('runReviewGate blocks on a high/critical finding', () => {
   const deps = gateDeps({
-    runPrReview: () => ({ findings: [{ severity: 'high', path: 'a.js', line: 5, message: 'bug' }] }),
+    runPrReview: () => ({ findings: [{ severity: 'high', path: 'a.js', line: 5, message: 'bug' }], posted: true }),
   });
   assert.throws(() => runReviewGate(gateArgs, deps), /blocking finding/);
 });
@@ -231,4 +231,38 @@ test('parseFinishArgs: --review-provider validates and --allow-no-checks parses'
   assert.equal(parseFinishArgs(['--gate-review', '--review-provider', 'claude']).reviewProvider, 'claude');
   assert.equal(parseFinishArgs(['--gate-review', '--allow-no-checks']).allowNoChecks, true);
   assert.throws(() => parseFinishArgs(['--review-provider', 'bogus']), /codex\|claude/);
+});
+
+test('runReviewGate refuses to merge when the review was not posted', () => {
+  // A verdict that never reached the PR leaves no evidence the diff was read,
+  // and an empty-findings result from a provider that silently returned
+  // nothing is indistinguishable from a genuine clean pass.
+  const deps = gateDeps({ runPrReview: () => ({ findings: [], posted: false }) });
+  assert.throws(() => runReviewGate(gateArgs, deps), /was not posted/);
+});
+
+test('runReviewGate names the auth cause and the artifact when nothing was posted', () => {
+  const deps = gateDeps({
+    runPrReview: () => ({
+      findings: [],
+      posted: false,
+      reason: 'github-auth-unavailable',
+      artifactPath: '/tmp/pr-1.md',
+    }),
+  });
+  assert.throws(
+    () => runReviewGate(gateArgs, deps),
+    (err) => /GitHub auth was unavailable/.test(err.message)
+      && /\/tmp\/pr-1\.md/.test(err.message),
+  );
+});
+
+test('runReviewGate does not merge on an unposted review even with zero findings', () => {
+  let merged = false;
+  const deps = gateDeps({
+    runPrReview: () => ({ findings: [], posted: undefined }),
+    markPullRequestReady: () => { merged = true; },
+  });
+  assert.throws(() => runReviewGate(gateArgs, deps));
+  assert.equal(merged, false, 'the PR must not even be promoted to ready');
 });


### PR DESCRIPTION
--gate-review merged lifted.sk-storefront #463, #465 and #466 each carrying
zero reviews and zero comments, after announcing "enforcing review + CI gate
before merge". The reviewer was fine — run by hand over #465's merged diff it
produced four findings, two of them real defects that had already shipped.

The gate treated an unposted review as a pass. runPrReview can return
posted: false — GitHub auth unavailable to the runner, or any path that writes
a local artifact instead of posting — and the gate only appended
"[not posted: …]" to a log line before promoting and merging.

That made two failures look like success: a provider that returned nothing is
indistinguishable from a clean review, and a verdict that never reached the PR
leaves nothing to audit. The merge gets recorded; the reasoning does not.

So !review.posted now throws, before markReady, naming the cause and the local
artifact path so the operator can read what the provider actually said before
re-running or passing --skip-review-gate.

Every runPrReview stub in the gate harnesses now returns posted: true, since
they all stand for a review that reached the PR; the three new tests are the
only ones that opt out. The default stub had been modelling the broken case.

858 tests, 41 failures — byte-identical to the pre-change failing set.

This is a guard, not a root cause: why the runner reported not-posted on that
machine is still open, since gh auth status succeeds interactively.