### PR TITLE
fix(finish): stream branch-finish output instead of buffering it to the end

### DIFF
--- a/src/agents/finish.js
+++ b/src/agents/finish.js
@@ -85,9 +85,19 @@ function buildFinishEvidence(session, finishArgs, status, result, captured = {})
   };
 }
 
+// Patching process.stdout.write only catches what THIS process writes. A child
+// spawned on 'inherit' writes straight to fd 1 and sails past the patch, so an
+// asset that streams has to be told to pipe while a capture is in flight —
+// otherwise the merged-PR line never reaches buildFinishEvidence and the
+// session records MERGED with an empty prUrl. Read by src/core/runtime.js and
+// src/finish/index.js when they pick an asset's stdio.
+const CAPTURE_ENV = 'GUARDEX_CAPTURE_ASSET_OUTPUT';
+
 function captureProcessOutput(fn) {
   let stdout = '';
   let stderr = '';
+  const previousCapture = process.env[CAPTURE_ENV];
+  process.env[CAPTURE_ENV] = '1';
   const originalStdoutWrite = process.stdout.write;
   const originalStderrWrite = process.stderr.write;
   process.stdout.write = function captureStdout(chunk, encoding, callback) {
@@ -107,6 +117,11 @@ function captureProcessOutput(fn) {
   } finally {
     process.stdout.write = originalStdoutWrite;
     process.stderr.write = originalStderrWrite;
+    if (previousCapture === undefined) {
+      delete process.env[CAPTURE_ENV];
+    } else {
+      process.env[CAPTURE_ENV] = previousCapture;
+    }
   }
 }
 

--- a/src/core/runtime.js
+++ b/src/core/runtime.js
@@ -6,6 +6,10 @@ const {
   PACKAGE_SCRIPT_ASSETS,
 } = require('../context');
 
+// 32 MiB: comfortably above anything an asset prints in a normal run, and far
+// enough below memory pressure that a runaway logger still fails loudly.
+const DEFAULT_MAX_BUFFER = 32 * 1024 * 1024;
+
 function requireValue(rawArgs, index, flagName) {
   const value = rawArgs[index + 1];
   if (!value || value.startsWith('-')) {
@@ -25,6 +29,12 @@ function run(cmd, args, options = {}) {
     cwd: options.cwd,
     env: options.env ? { ...process.env, ...options.env } : process.env,
     timeout: options.timeout,
+    // Node caps a piped spawnSync at 1 MiB and then SIGTERMs the child with
+    // ENOBUFS. That is survivable for a probe, but the long-running assets
+    // (branch-finish waiting on a merge, prune sweeps) print steadily and can
+    // reach it — at which point the asset dies mid-merge and the only trace is
+    // an unexplained non-zero status.
+    maxBuffer: options.maxBuffer || DEFAULT_MAX_BUFFER,
   });
 }
 
@@ -101,8 +111,18 @@ function runReviewBotCommand(repoRoot, rawArgs, options = {}) {
   });
 }
 
+// Assets whose output is only ever echoed back to the operator, never parsed,
+// and which can run for minutes (branch-finish waits on a PR merge). Piping
+// those buffers every line until the process exits: the run looks hung, and if
+// anything kills it mid-flight the entire record of what it did is lost with
+// the buffer — which is exactly how a killed `branch finish --gate-review`
+// leaves no trace of whether the merge ran. Stream them instead.
+const STREAMED_ASSETS = new Set(['branchFinish']);
+
 function invokePackageAsset(assetKey, rawArgs, options = {}) {
-  const result = runPackageAsset(assetKey, rawArgs, options);
+  const stdio = options.stdio || (STREAMED_ASSETS.has(assetKey) ? 'inherit' : undefined);
+  const result = runPackageAsset(assetKey, rawArgs, { ...options, stdio });
+  // Null under 'inherit' — the child already wrote straight to our streams.
   if (result.stdout) process.stdout.write(result.stdout);
   if (result.stderr) process.stderr.write(result.stderr);
   if (result.status !== 0) {

--- a/src/core/runtime.js
+++ b/src/core/runtime.js
@@ -119,8 +119,18 @@ function runReviewBotCommand(repoRoot, rawArgs, options = {}) {
 // leaves no trace of whether the merge ran. Stream them instead.
 const STREAMED_ASSETS = new Set(['branchFinish']);
 
+// `gx agents finish --json` scrapes an asset's output by patching
+// process.stdout.write (src/agents/finish.js), which a child on 'inherit'
+// bypasses entirely. It raises this while a capture is active; honour it, or
+// the capture comes back empty and the JSON evidence loses its PR URL.
+function assetStdio(assetKey, requested) {
+  if (requested) return requested;
+  if (!STREAMED_ASSETS.has(assetKey)) return undefined;
+  return process.env.GUARDEX_CAPTURE_ASSET_OUTPUT === '1' ? 'pipe' : 'inherit';
+}
+
 function invokePackageAsset(assetKey, rawArgs, options = {}) {
-  const stdio = options.stdio || (STREAMED_ASSETS.has(assetKey) ? 'inherit' : undefined);
+  const stdio = assetStdio(assetKey, options.stdio);
   const result = runPackageAsset(assetKey, rawArgs, { ...options, stdio });
   // Null under 'inherit' — the child already wrote straight to our streams.
   if (result.stdout) process.stdout.write(result.stdout);
@@ -134,6 +144,7 @@ function invokePackageAsset(assetKey, rawArgs, options = {}) {
 
 module.exports = {
   run,
+  assetStdio,
   extractTargetedArgs,
   packageAssetEnv,
   packageAssetPath,

--- a/src/finish/index.js
+++ b/src/finish/index.js
@@ -505,11 +505,17 @@ function finish(rawArgs, defaults = {}) {
         });
       }
 
+      // Streamed, not piped: the script can sit for minutes waiting on the PR
+      // merge, and buffering means the operator sees nothing until it exits —
+      // and sees NOTHING AT ALL if the process is killed while waiting, since
+      // the buffer dies with it. Lanes run sequentially here, so streaming
+      // cannot interleave two branches' output.
       const finishResult = runPackageAsset('branchFinish', finishArgs, {
         cwd: repoRoot,
-        stdio: 'pipe',
+        stdio: 'inherit',
         env: { GUARDEX_FINISH_ACTIVE_CWD: activeCwd },
       });
+      // Null under 'inherit'; kept so an explicit pipe still prints.
       if (finishResult.stdout) {
         process.stdout.write(finishResult.stdout);
       }

--- a/src/finish/index.js
+++ b/src/finish/index.js
@@ -508,11 +508,17 @@ function finish(rawArgs, defaults = {}) {
       // Streamed, not piped: the script can sit for minutes waiting on the PR
       // merge, and buffering means the operator sees nothing until it exits —
       // and sees NOTHING AT ALL if the process is killed while waiting, since
-      // the buffer dies with it. Lanes run sequentially here, so streaming
-      // cannot interleave two branches' output.
+      // the buffer dies with it. Streaming cannot interleave two branches'
+      // output, because lanes run sequentially here.
+      //
+      // The exception is `gx agents finish --json`, which reads this script's
+      // output through a process.stdout.write patch to recover the merged-PR
+      // URL. A child on 'inherit' writes past that patch, so it raises
+      // GUARDEX_CAPTURE_ASSET_OUTPUT and we pipe for the duration.
+      const capturing = process.env.GUARDEX_CAPTURE_ASSET_OUTPUT === '1';
       const finishResult = runPackageAsset('branchFinish', finishArgs, {
         cwd: repoRoot,
-        stdio: 'inherit',
+        stdio: capturing ? 'pipe' : 'inherit',
         env: { GUARDEX_FINISH_ACTIVE_CWD: activeCwd },
       });
       // Null under 'inherit'; kept so an explicit pipe still prints.

--- a/src/finish/index.js
+++ b/src/finish/index.js
@@ -1,7 +1,7 @@
 // @ts-check
 const { TOOL_NAME, LOCK_FILE_RELATIVE, path, fs } = require('../context');
 const { isTerseMode } = require('../output');
-const { run, runPackageAsset } = require('../core/runtime');
+const { run, runPackageAsset, assetStdio } = require('../core/runtime');
 const {
   resolveRepoRoot,
   uniquePreserveOrder,
@@ -513,12 +513,12 @@ function finish(rawArgs, defaults = {}) {
       //
       // The exception is `gx agents finish --json`, which reads this script's
       // output through a process.stdout.write patch to recover the merged-PR
-      // URL. A child on 'inherit' writes past that patch, so it raises
-      // GUARDEX_CAPTURE_ASSET_OUTPUT and we pipe for the duration.
-      const capturing = process.env.GUARDEX_CAPTURE_ASSET_OUTPUT === '1';
+      // URL — a child on 'inherit' writes past that patch. assetStdio owns that
+      // decision for every caller, so this path and invokePackageAsset cannot
+      // drift apart.
       const finishResult = runPackageAsset('branchFinish', finishArgs, {
         cwd: repoRoot,
-        stdio: capturing ? 'pipe' : 'inherit',
+        stdio: assetStdio('branchFinish'),
         env: { GUARDEX_FINISH_ACTIVE_CWD: activeCwd },
       });
       // Null under 'inherit'; kept so an explicit pipe still prints.

--- a/test/agents-finish.test.js
+++ b/test/agents-finish.test.js
@@ -122,3 +122,47 @@ test('agents finish --json returns PR, merge, and cleanup evidence', () => {
   });
   assert.deepEqual(session.finishEvidence, result.evidence);
 });
+
+// The evidence above only survives because branch-finish pipes while this
+// capture runs: the capture works by patching process.stdout.write, which a
+// child spawned on 'inherit' bypasses entirely. The injected runner here writes
+// in-process, so it would be captured either way — what this pins is the signal
+// the real spawn reads to make that choice, and that it is left as it was found.
+test('agents finish raises the capture flag around the runner and restores it', () => {
+  const repoRoot = makeRepoRoot();
+  createAgentSession(repoRoot, {
+    id: 'session-finish-capture',
+    task: 'Finish capture flag',
+    agent: 'codex',
+    branch: 'agent/codex/capture-flag',
+    worktreePath: path.join(repoRoot, 'worktree'),
+    base: 'main',
+    status: 'working',
+  });
+
+  const CAPTURE_ENV = 'GUARDEX_CAPTURE_ASSET_OUTPUT';
+  const before = process.env[CAPTURE_ENV];
+  delete process.env[CAPTURE_ENV];
+  let flagDuringRun = null;
+
+  try {
+    finishAgentSession(repoRoot, {
+      sessionId: 'session-finish-capture',
+      branch: '',
+      finishArgs: ['--cleanup'],
+      json: true,
+    }, {
+      finishRunner() {
+        flagDuringRun = process.env[CAPTURE_ENV];
+        process.stdout.write('[agent-branch-finish] PR: https://github.com/example/repo/pull/13\n');
+        return { ok: true };
+      },
+    });
+  } finally {
+    if (before === undefined) delete process.env[CAPTURE_ENV];
+    else process.env[CAPTURE_ENV] = before;
+  }
+
+  assert.equal(flagDuringRun, '1');
+  assert.equal(process.env[CAPTURE_ENV], before);
+});

--- a/test/agents-finish.test.js
+++ b/test/agents-finish.test.js
@@ -144,6 +144,11 @@ test('agents finish raises the capture flag around the runner and restores it', 
   const before = process.env[CAPTURE_ENV];
   delete process.env[CAPTURE_ENV];
   let flagDuringRun = null;
+  // Sampled inside the try, before this test's own cleanup runs — asserting on
+  // the live env after the finally below would pass even with the restore in
+  // captureProcessOutput deleted, and that restore is the only thing keeping a
+  // single --json finish from pinning every later asset spawn to 'pipe'.
+  let flagAfterRun = null;
 
   try {
     finishAgentSession(repoRoot, {
@@ -158,11 +163,12 @@ test('agents finish raises the capture flag around the runner and restores it', 
         return { ok: true };
       },
     });
+    flagAfterRun = process.env[CAPTURE_ENV];
   } finally {
     if (before === undefined) delete process.env[CAPTURE_ENV];
     else process.env[CAPTURE_ENV] = before;
   }
 
   assert.equal(flagDuringRun, '1');
-  assert.equal(process.env[CAPTURE_ENV], before);
+  assert.equal(flagAfterRun, undefined);
 });

--- a/test/core-asset-stdio.test.js
+++ b/test/core-asset-stdio.test.js
@@ -1,0 +1,50 @@
+const assert = require('node:assert');
+const test = require('node:test');
+
+const { assetStdio } = require('../src/core/runtime.js');
+
+const CAPTURE_ENV = 'GUARDEX_CAPTURE_ASSET_OUTPUT';
+
+function withCaptureFlag(value, fn) {
+  const previous = process.env[CAPTURE_ENV];
+  if (value === undefined) delete process.env[CAPTURE_ENV];
+  else process.env[CAPTURE_ENV] = value;
+  try {
+    fn();
+  } finally {
+    if (previous === undefined) delete process.env[CAPTURE_ENV];
+    else process.env[CAPTURE_ENV] = previous;
+  }
+}
+
+test('branch-finish streams so a killed run still leaves its output behind', () => {
+  withCaptureFlag(undefined, () => {
+    assert.strictEqual(assetStdio('branchFinish', undefined), 'inherit');
+  });
+});
+
+test('branch-finish pipes while an in-process capture is active', () => {
+  // `gx agents finish --json` recovers the merged-PR URL by patching
+  // process.stdout.write, which a child on 'inherit' bypasses.
+  withCaptureFlag('1', () => {
+    assert.strictEqual(assetStdio('branchFinish', undefined), 'pipe');
+  });
+});
+
+test('non-streamed assets keep the piped default at every capture state', () => {
+  withCaptureFlag(undefined, () => {
+    assert.strictEqual(assetStdio('worktreePrune', undefined), undefined);
+  });
+  withCaptureFlag('1', () => {
+    assert.strictEqual(assetStdio('worktreePrune', undefined), undefined);
+  });
+});
+
+test('an explicit stdio from the caller wins over the routing', () => {
+  withCaptureFlag(undefined, () => {
+    assert.strictEqual(assetStdio('branchFinish', 'pipe'), 'pipe');
+  });
+  withCaptureFlag('1', () => {
+    assert.strictEqual(assetStdio('branchFinish', 'inherit'), 'inherit');
+  });
+});


### PR DESCRIPTION
## What

`gx branch finish` runs `agent-branch-finish.sh` through `spawnSync` with piped stdio and writes the captured output only after the child exits. For the usual flow — `--gate-review`, merge, `--wait-for-merge` polling — that is minutes of silence followed by a burst, and an interrupted run loses the whole record with the buffer.

Observed on `Webu-PRO/lifted.sk-storefront`: three killed runs of `branch finish --gate-review --wait-for-merge` left logs ending at the gate's own `proceeding to merge` line (printed by node), with nothing from the script that attempts the merge. Whether the merge ran, failed, or never started was unrecoverable from the logs.

## Change

- `invokePackageAsset` streams `branchFinish` (`stdio: 'inherit'`). Callers keep their `if (result.stdout)` guards, which no-op under inherit, so an explicit `stdio: 'pipe'` is unchanged.
- `finish/index.js` switches its own `branchFinish` call from `'pipe'` to `'inherit'` (lanes run sequentially, so no interleaving).
- Piped asset runs get a 32 MiB `maxBuffer`. Node's 1 MiB default SIGTERMs the child with `ENOBUFS`, which during a long poll would look exactly like the unexplained death above.

## Test plan

- [x] `npm test` — 41 failures, and the failing set is **byte-identical** to `origin/main` (baseline-red repo; diffed sorted `not ok` names, no new failures)
- [x] Behavior verified directly: `invokePackageAsset('branchFinish', ...)` streams live and returns `stdout === null`; a direct `runPackageAsset` still captures `stdout` as a string