### PR TITLE
fix(stop-hook): gate the unattended finish instead of merging unreviewed

### DIFF
--- a/openspec/changes/agent-claude-gate-the-stop-hook-2026-08-12-00-18/.openspec.yaml
+++ b/openspec/changes/agent-claude-gate-the-stop-hook-2026-08-12-00-18/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/agent-claude-gate-the-stop-hook-2026-08-12-00-18/notes.md
+++ b/openspec/changes/agent-claude-gate-the-stop-hook-2026-08-12-00-18/notes.md
@@ -1,0 +1,16 @@
+# agent-claude-gate-the-stop-hook-2026-08-12-00-18 (minimal / T1)
+
+Branch: `agent/<your-name>/<branch-slug>`
+
+Describe the change in a sentence or two. Commit message is the spec of record.
+
+## Handoff
+
+- Handoff: change=`agent-claude-gate-the-stop-hook-2026-08-12-00-18`; branch=`agent/<your-name>/<branch-slug>`; scope=`TODO`; action=`continue this sandbox or finish cleanup after a usage-limit/manual takeover`.
+- Copy prompt: Continue `agent-claude-gate-the-stop-hook-2026-08-12-00-18` on branch `agent/<your-name>/<branch-slug>`. Work inside the existing sandbox, review `openspec/changes/agent-claude-gate-the-stop-hook-2026-08-12-00-18/notes.md`, continue from the current state instead of creating a new sandbox, and when the work is done run `gx branch finish --branch agent/<your-name>/<branch-slug> --base dev --via-pr --wait-for-merge --cleanup`.
+
+## Cleanup
+
+- [ ] Run: `gx branch finish --branch agent/<your-name>/<branch-slug> --base dev --via-pr --wait-for-merge --cleanup`
+- [ ] Record PR URL + `MERGED` state in the completion handoff.
+- [ ] Confirm sandbox worktree is gone (`git worktree list`, `git branch -a`).

--- a/templates/scripts/agent-claude-stop-finish.sh
+++ b/templates/scripts/agent-claude-stop-finish.sh
@@ -153,7 +153,22 @@ if [[ "$dirty" -eq 0 && "$ahead" -eq 0 ]]; then
   exit 0
 fi
 
-finish_cmd=(branch finish --branch "$branch" --base "$base_branch" --via-pr --wait-for-merge --cleanup)
+# --gate-review is not optional here. This hook fires unattended at the end of
+# every agent turn, so a bare --via-pr lands the work with NOTHING having read
+# it: the merge runs as soon as the *required* checks pass, and a repo without
+# branch protection has none. Measured on opencue/gitguardex #700 —
+# ready_for_review at 22:05:56Z, merged at 22:06:00Z, four seconds later, zero
+# reviews on the PR, while a separately launched gated run was still reviewing
+# that very branch.
+#
+# The gate is fail-closed: a CRITICAL/HIGH finding, red CI, or a PR GitHub will
+# not merge each abort before the merge runs. Auto-landing unreviewed agent work
+# is the outcome this tool exists to prevent.
+finish_cmd=(
+  branch finish --branch "$branch" --base "$base_branch" --via-pr
+  --gate-review --review-provider claude
+  --wait-for-merge --cleanup
+)
 
 if [[ "$dirty" -gt 0 && "$mode" == "clean" ]]; then
   echo "[agent-claude-stop-finish] ${branch}: ${dirty} uncommitted change(s); clean-only mode left the sandbox open." >&2

--- a/test/agent-claude-stop-finish.test.js
+++ b/test/agent-claude-stop-finish.test.js
@@ -72,6 +72,13 @@ defineSpawnSuite('agent-claude-stop-finish', () => {
       '--base',
       'main',
       '--via-pr',
+      // The hook runs unattended, so it must hand off a GATED finish. Without
+      // these two flags the merge lands with nothing having reviewed it — four
+      // seconds after the PR left draft, on a repo with no required checks
+      // (opencue/gitguardex #700).
+      '--gate-review',
+      '--review-provider',
+      'claude',
       '--wait-for-merge',
       '--cleanup',
     ]);


### PR DESCRIPTION
## Summary
- fix(stop-hook): gate the unattended finish instead of merging unreviewed
- fix(finish): stream branch-finish output instead of buffering it to the end (#699)
- fix(gate): unstick the merge gate — stale head, unbounded review, merged-PR misread (#700)

## Test plan
- [ ] verified locally