### PR TITLE
ci(hooks): assert .codex/hooks/*.py are symlinks, not copies

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Static check CLI entrypoint
         run: node --check bin/multiagent-safety.js
 
-      - name: Check scripts/ ↔ templates/scripts/ symlink parity
+      - name: Check mirrored-tree symlink parity (scripts/, .codex/hooks/)
         run: bash scripts/check-script-symlinks.sh
 
       - name: Package dry run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Static check CLI entrypoint
         run: node --check bin/multiagent-safety.js
 
-      - name: Check scripts/ ↔ templates/scripts/ symlink parity
+      - name: Check mirrored-tree symlink parity (scripts/, .codex/hooks/)
         run: bash scripts/check-script-symlinks.sh
 
       - name: Package dry run

--- a/openspec/changes/agent-claude-assert-codex-hooks-are-symlinks-in-ci-2026-08-17-10-07/.openspec.yaml
+++ b/openspec/changes/agent-claude-assert-codex-hooks-are-symlinks-in-ci-2026-08-17-10-07/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-17

--- a/openspec/changes/agent-claude-assert-codex-hooks-are-symlinks-in-ci-2026-08-17-10-07/notes.md
+++ b/openspec/changes/agent-claude-assert-codex-hooks-are-symlinks-in-ci-2026-08-17-10-07/notes.md
@@ -1,0 +1,52 @@
+# agent-claude-assert-codex-hooks-are-symlinks-in-ci-2026-08-17-10-07 (minimal / T1)
+
+Branch: `agent/claude/assert-codex-hooks-are-symlinks-in-ci-2026-08-17-10-07`
+
+Extends `scripts/check-script-symlinks.sh` to assert the second mirrored tree:
+every tracked `.codex/hooks/*.py` must be a relative symlink to
+`../../.claude/hooks/<same-name>`, non-dangling.
+
+Follow-up to the review of #703, which landed
+`.codex/hooks/{agent_branch_advisor,_session_presence}.py` as real file copies
+while the other four entries were symlinks. `HOOKS.md` declares symlinks the
+contract and names a SHA1 CI assertion as the only alternative; neither was in
+place, so nothing caught it.
+
+## Design note
+
+The hook list is derived from `git ls-files -- '.codex/hooks/*.py'`, not a
+hand-maintained array like `required_symlinks`. A fixed list would not have
+caught #703: whoever adds a hook as a copy is exactly the person who would not
+think to add it to the list. Glob-derived means a hook added tomorrow is covered
+the moment it lands.
+
+Failure hints are printed per-tree so a hooks-only failure does not lead with a
+`scripts/` fix command that repairs nothing.
+
+No workflow edit needed: `.github/workflows/ci.yml:61` and `ci-full.yml:57`
+already run this script.
+
+## Verification
+
+| Case | Result |
+|---|---|
+| `bash -n` syntax | OK |
+| Clean tree | `OK: 14 paired script(s), 6 hook symlink(s) verified.` exit 0 |
+| Hook as real copy (the #703 defect) | `not a symlink: .codex/hooks/...` exit 1 |
+| Hook wrong symlink target | `wrong symlink target: ... (expected ...)` exit 1 |
+| Hook dangling target | caught, exit 1 |
+| Hooks-only failure | prints only the `.codex/hooks/` hint |
+| Scripts-only failure | prints only the `scripts/` hint |
+
+Tree restored after each negative case; `git status` shows only
+`scripts/check-script-symlinks.sh` modified.
+
+## Handoff
+
+- Handoff: change=`agent-claude-assert-codex-hooks-are-symlinks-in-ci-2026-08-17-10-07`; branch=`agent/claude/assert-codex-hooks-are-symlinks-in-ci-2026-08-17-10-07`; scope=`scripts/check-script-symlinks.sh`; action=`finish via PR into main`.
+
+## Cleanup
+
+- [ ] Run: `gx branch finish --branch agent/claude/assert-codex-hooks-are-symlinks-in-ci-2026-08-17-10-07 --base main --via-pr --wait-for-merge --cleanup`
+- [ ] Record PR URL + `MERGED` state in the completion handoff.
+- [ ] Confirm sandbox worktree is gone (`git worktree list`, `git branch -a`).

--- a/scripts/check-script-symlinks.sh
+++ b/scripts/check-script-symlinks.sh
@@ -73,26 +73,30 @@ while IFS= read -r path; do
   [[ -n "$path" ]] && hook_symlinks+=("$path")
 done < <(git ls-files -- '.codex/hooks/*.py')
 
+# The loop is guarded rather than run on a possibly-empty array: bash < 4.4
+# (macOS system bash 3.2) treats "${arr[@]}" on an empty array as an unbound
+# variable under `set -u`, which would crash here instead of reporting the
+# problem below.
 if [[ ${#hook_symlinks[@]} -eq 0 ]]; then
   problems+=("no tracked hooks found under .codex/hooks/ (expected the .claude/hooks/ mirror)")
+else
+  for path in "${hook_symlinks[@]}"; do
+    if [[ ! -L "$path" ]]; then
+      problems+=("not a symlink: $path")
+      continue
+    fi
+    expected_target="../../.claude/hooks/$(basename "$path")"
+    target="$(readlink "$path")"
+    if [[ "$target" != "$expected_target" ]]; then
+      problems+=("wrong symlink target: $path -> $target (expected $expected_target)")
+      continue
+    fi
+    if [[ ! -f "$path" ]]; then
+      problems+=("symlink dangling (target file missing): $path -> $target")
+      continue
+    fi
+  done
 fi
-
-for path in "${hook_symlinks[@]}"; do
-  if [[ ! -L "$path" ]]; then
-    problems+=("not a symlink: $path")
-    continue
-  fi
-  expected_target="../../.claude/hooks/$(basename "$path")"
-  target="$(readlink "$path")"
-  if [[ "$target" != "$expected_target" ]]; then
-    problems+=("wrong symlink target: $path -> $target (expected $expected_target)")
-    continue
-  fi
-  if [[ ! -f "$path" ]]; then
-    problems+=("symlink dangling (target file missing): $path -> $target")
-    continue
-  fi
-done
 
 if [[ ${#problems[@]} -gt 0 ]]; then
   echo "[check-script-symlinks] FAIL: ${#problems[@]} problem(s) detected." >&2

--- a/scripts/check-script-symlinks.sh
+++ b/scripts/check-script-symlinks.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
-# Verify every paired script under scripts/ is a symlink to templates/scripts/.
-# Single source of truth lives in templates/scripts/ because the gx CLI invokes
-# templates/scripts/ at runtime (see src/context.js:247, PACKAGE_SCRIPT_ASSETS).
+# Verify the repo's two mirrored trees are symlinks, not copies:
+#
+#   scripts/        -> templates/scripts/   (single source of truth: the gx CLI
+#                                            invokes templates/scripts/ at runtime,
+#                                            see src/context.js:247,
+#                                            PACKAGE_SCRIPT_ASSETS)
+#   .codex/hooks/   -> .claude/hooks/       (both harnesses must execute the same
+#                                            hook code, see .claude/hooks/HOOKS.md)
+#
 # Without this guard, contributors silently re-introduce the scripts/ ↔ templates/scripts/
-# drift that PR #547 had to fix retroactively.
+# drift that PR #547 had to fix retroactively, or the .codex/hooks/ ↔ .claude/hooks/
+# drift that PR #703 landed (two hooks committed as real copies).
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
@@ -54,14 +61,57 @@ for path in "${required_symlinks[@]}"; do
   fi
 done
 
+script_problem_count=${#problems[@]}
+
+# Every tracked hook under .codex/hooks/ MUST be a relative symlink to its
+# .claude/hooks/ counterpart. Derived from the tracked file list rather than a
+# hand-maintained array on purpose: a hook added tomorrow is covered the moment
+# it lands. A fixed list would not have caught PR #703, because nobody adding a
+# new hook would have thought to extend the list.
+hook_symlinks=()
+while IFS= read -r path; do
+  [[ -n "$path" ]] && hook_symlinks+=("$path")
+done < <(git ls-files -- '.codex/hooks/*.py')
+
+if [[ ${#hook_symlinks[@]} -eq 0 ]]; then
+  problems+=("no tracked hooks found under .codex/hooks/ (expected the .claude/hooks/ mirror)")
+fi
+
+for path in "${hook_symlinks[@]}"; do
+  if [[ ! -L "$path" ]]; then
+    problems+=("not a symlink: $path")
+    continue
+  fi
+  expected_target="../../.claude/hooks/$(basename "$path")"
+  target="$(readlink "$path")"
+  if [[ "$target" != "$expected_target" ]]; then
+    problems+=("wrong symlink target: $path -> $target (expected $expected_target)")
+    continue
+  fi
+  if [[ ! -f "$path" ]]; then
+    problems+=("symlink dangling (target file missing): $path -> $target")
+    continue
+  fi
+done
+
 if [[ ${#problems[@]} -gt 0 ]]; then
   echo "[check-script-symlinks] FAIL: ${#problems[@]} problem(s) detected." >&2
   printf '  - %s\n' "${problems[@]}" >&2
-  echo "" >&2
-  echo "[check-script-symlinks] The scripts/ paired files must be symlinks into ../templates/scripts/." >&2
-  echo "[check-script-symlinks] Fix with (for each offender):" >&2
-  echo "  rm scripts/<file> && ln -s ../templates/scripts/<file> scripts/<file>" >&2
+  # Only show the fix hint for the tree that actually broke, so a hooks-only
+  # failure does not lead with a scripts/ command that fixes nothing.
+  if [[ $script_problem_count -gt 0 ]]; then
+    echo "" >&2
+    echo "[check-script-symlinks] The scripts/ paired files must be symlinks into ../templates/scripts/." >&2
+    echo "[check-script-symlinks] Fix with (for each offender):" >&2
+    echo "  rm scripts/<file> && ln -s ../templates/scripts/<file> scripts/<file>" >&2
+  fi
+  if [[ ${#problems[@]} -gt $script_problem_count ]]; then
+    echo "" >&2
+    echo "[check-script-symlinks] The .codex/hooks/ files must be symlinks into ../../.claude/hooks/." >&2
+    echo "[check-script-symlinks] Edit only .claude/hooks/; fix a copy with:" >&2
+    echo "  rm .codex/hooks/<file> && ln -s ../../.claude/hooks/<file> .codex/hooks/<file>" >&2
+  fi
   exit 1
 fi
 
-echo "[check-script-symlinks] OK: ${#required_symlinks[@]} paired script(s) verified."
+echo "[check-script-symlinks] OK: ${#required_symlinks[@]} paired script(s), ${#hook_symlinks[@]} hook symlink(s) verified."


### PR DESCRIPTION
## Summary

Extends `scripts/check-script-symlinks.sh` to guard the repo's **second** mirrored tree: every tracked `.codex/hooks/*.py` must be a non-dangling relative symlink to `../../.claude/hooks/<same-name>`.

Follow-up to the review of #703, which landed `agent_branch_advisor.py` and `_session_presence.py` as real file copies while the other four entries in that directory were symlinks. `.claude/hooks/HOOKS.md` declares symlinks the contract and names a SHA1 CI assertion as the only sanctioned alternative — neither was in place, so nothing caught it.

Beyond drift, a copy breaks behavior: `_session_presence.state_dir()` is `Path(__file__).resolve().parent / "state"`, so a copy resolves to `.codex/hooks/state/` instead of the shared `.claude/hooks/state/`, splitting the cross-harness presence registry the module exists to provide.

## Design note

The hook list is derived from `git ls-files -- '.codex/hooks/*.py'`, not a hand-maintained array like `required_symlinks`. **A fixed list would not have caught #703** — whoever adds a hook as a copy is exactly the person who would not think to extend the list. Glob-derived means a hook added tomorrow is covered the moment it lands.

Fix hints print per-tree, so a hooks-only failure no longer leads with a `scripts/` command that repairs nothing.

No new workflow step: `ci.yml` and `ci-full.yml` already invoke this script. The step was renamed, since the old label described only half of what it now checks.

## Test plan

- [x] `bash -n` syntax check
- [x] Clean tree -> `OK: 14 paired script(s), 6 hook symlink(s) verified.` exit 0
- [x] Hook as a real copy (the #703 defect) -> `not a symlink: ...` exit 1
- [x] Hook with wrong symlink target -> `wrong symlink target: ... (expected ...)` exit 1
- [x] Hook with dangling target -> caught, exit 1
- [x] Hooks-only failure prints only the `.codex/hooks/` hint
- [x] Scripts-only failure prints only the `scripts/` hint
- [x] Empty-array path under `set -u` (bash 3.2 / macOS) reaches the reporting branch instead of crashing
- [x] CI green on head `5fffb9b`: renamed step ran and printed the new output
