### PR TITLE
fix(security): raise the repository Scorecard baseline

### DIFF
--- a/.github/workflows/e2e-finish.yml
+++ b/.github/workflows/e2e-finish.yml
@@ -52,7 +52,7 @@ jobs:
           node-version: 20
 
       - name: Install
-        run: npm install --ignore-scripts
+        run: npm ci --ignore-scripts
 
       - name: Configure git identity (needed by gx setup hooks)
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,14 +15,15 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   release-please:
     if: github.repository == 'opencue/gitguardex'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Run release-please

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,16 +81,19 @@ jobs:
         run: echo "${PACKAGE_NAME}@${PACKAGE_VERSION} is already on npm; skipping publish."
 
       - name: Generate release checksum
+        if: ${{ always() && steps.pack.outputs.package_path != '' }}
         run: |
           sha256sum "${{ steps.pack.outputs.package_path }}" > "${{ steps.pack.outputs.package_path }}.sha256"
 
       - name: Sign release tarball with Sigstore
+        if: ${{ always() && steps.pack.outputs.package_path != '' }}
         run: |
           cosign sign-blob "${{ steps.pack.outputs.package_path }}" \
             --bundle "${{ steps.pack.outputs.package_path }}.sigstore.json" \
             --yes
 
       - name: Upload signed release assets
+        if: ${{ always() && steps.pack.outputs.package_path != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name || format('v{0}', steps.pkg.outputs.version) }}

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -59,8 +59,39 @@ test('release workflow uploads signed GitHub release assets for the package tarb
   assert.match(workflow, /cosign sign-blob "\$\{\{\s*steps\.pack\.outputs\.package_path\s*\}\}"/);
   assert.match(workflow, /--bundle "\$\{\{\s*steps\.pack\.outputs\.package_path\s*\}\}\.sigstore\.json"/);
   assert.match(workflow, /name:\s+Upload signed release assets/);
+  const resilientReleaseSteps = workflow.match(
+    /- name:\s+Generate release checksum[\s\S]*?- name:\s+Upload signed release assets[\s\S]*?--clobber/,
+  )?.[0] ?? '';
+  assert.equal(
+    resilientReleaseSteps.match(/if:\s+\$\{\{\s*always\(\)\s*&&\s*steps\.pack\.outputs\.package_path != ''\s*\}\}/g)?.length,
+    3,
+    'checksum, signing, and upload must still run when npm publishing fails after packing',
+  );
   assert.match(workflow, /GH_TOKEN:\s+\$\{\{\s*github\.token\s*\}\}/);
   assert.match(workflow, /gh release upload "\$RELEASE_TAG"/);
+});
+
+test('release-please grants write permissions only to its release job', () => {
+  const workflowPath = path.join(repoRoot, '.github', 'workflows', 'release-please.yml');
+  const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+  assert.match(workflow, /^permissions:\s+read-all$/m);
+  assert.match(
+    workflow,
+    /release-please:[\s\S]*?permissions:\s*\n\s+contents:\s+write\s*\n\s+pull-requests:\s+write/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /^permissions:\s*\n\s+contents:\s+write\s*\n\s+pull-requests:\s+write/m,
+  );
+});
+
+test('workflow dependency installs use lockfile-enforcing npm ci', () => {
+  const workflowDir = path.join(repoRoot, '.github', 'workflows');
+  for (const file of fs.readdirSync(workflowDir).filter((name) => /\.ya?ml$/.test(name))) {
+    const workflow = fs.readFileSync(path.join(workflowDir, file), 'utf8');
+    assert.doesNotMatch(workflow, /run:\s+npm install(?:\s|$)/, `${file} bypasses its npm lockfile`);
+  }
 });
 
 test('release workflow only publishes from published releases or manual dispatch', () => {


### PR DESCRIPTION
## Summary
- scope release-please write permissions to its job
- enforce lockfile installs in the e2e workflow
- keep checksum, Sigstore signing, and GitHub asset upload running after an npm publish failure
- add workflow metadata regression coverage

## Verification
- `npm run verify` (987 pass, 0 fail, 1 skip)
- `npm audit --audit-level=high`
- `npm audit --prefix frontend --audit-level=high`

## Baseline
- OpenSSF Scorecard on `main`: 7.2/10 (run 33105208544)