### PR TITLE
fix(release): use an OIDC-capable npm runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,22 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
-          cache: npm
+          package-manager-cache: false
+
+      - name: Verify npm trusted-publishing support
+        run: |
+          npm_version="$(npm --version)"
+          node - "$npm_version" <<'NODE'
+          const version = process.argv[2];
+          const [major = 0, minor = 0, patch = 0] = version.split('.').map(Number);
+          const supported = major > 11 || (major === 11 && (minor > 5 || (minor === 5 && patch >= 1)));
+          if (!supported) {
+            console.error(`npm ${version} cannot use OIDC trusted publishing; requires npm >=11.5.1`);
+            process.exit(1);
+          }
+          NODE
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -31,6 +31,12 @@ test('release workflow publishes with provenance in CI', () => {
   const workflowPath = path.join(repoRoot, '.github', 'workflows', 'release.yml');
   const workflow = fs.readFileSync(workflowPath, 'utf8');
   assert.match(workflow, /name:\s+Checkout\s+uses:\s+actions\/checkout@[0-9a-f]{40}[^\n]*\n\s+with:\s*\n\s+fetch-depth:\s+0/s);
+  assert.match(workflow, /node-version:\s+24/);
+  assert.match(workflow, /package-manager-cache:\s+false/);
+  assert.doesNotMatch(workflow, /^\s+cache:\s+npm$/m);
+  assert.match(workflow, /name:\s+Verify npm trusted-publishing support/);
+  assert.match(workflow, /npm_version="\$\(npm --version\)"/);
+  assert.match(workflow, /requires npm >=11\.5\.1/);
   assert.match(workflow, /npm publish --provenance --access public/);
   // Cosign installer must be pinned to a 40-char SHA on the v4.1.x line.
   // The patch version floats so a renovate/dependabot bump


### PR DESCRIPTION
## Root cause
The configured npm Trusted Publisher is correct, but the release runner used Node 22.23.2 with npm 10.9.8. npm trusted publishing requires npm 11.5.1+, so publish fell back to unauthorized token auth and returned E404.

## Fix
- publish on Node 24 (currently bundles npm 11.19.0)
- fail fast when npm is below 11.5.1
- disable dependency caching in the release workflow
- add regression assertions

## Verification
- `node --test test/metadata.test.js`
- `npm run verify` (987 pass, 0 fail, 1 skip)
- `npm audit --audit-level=high`